### PR TITLE
Only War 2017b

### DIFF
--- a/Only War/Only War.html
+++ b/Only War/Only War.html
@@ -1,2070 +1,1305 @@
-<div class="sheet-wrapper">
-
-<!-- Basic Character Information -->
-<!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
-
-<div class="sheet-3colrow">
-
-    <!-- Left Column  -->
-    <div class="sheet-col">
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:35%"><label>Character Name</label></div>
-            <div class="sheet-item" style="width:60%"><input name="attr_character_name" type="text"></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:25%"><label>Homeworld</label></div>
-            <div class="sheet-item" style="width:70%"><input name="attr_Homeworld" type="text"></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:25%"><label>Regiment</label></div>
-            <div class="sheet-item" style="width:70%"><input name="attr_Regiment" type="text"></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:25%"><label>Speciality</label></div>
-            <div class="sheet-item" style="width:70%"><input name="attr_Speciality" type="text"></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:25%"><label>Demeanour</label></div>
-            <div class="sheet-item" style="width:70%"><input name="attr_Demeanour" type="text"></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:15%"><label>Notes</label></div>
-            <div class="sheet-item" style="width:80%"><input name="attr_Notes" type="text"></div>
-        </div>
-    </div>
-
-    <!-- Mid Column (Logo) -->
-    <div class="sheet-col">
-        <h2>Only War</h2>
-        <img src="https://41.media.tumblr.com/9c63660ca1d5fb6ddfb57338d2bfcb03/tumblr_ntwstyGU0y1s9slulo1_r2_500.png">
-        <!--
+<div class="sheet-wrapper"><!-- Basic Character Information --> <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+<div class="sheet-3colrow"><!-- Left Column  -->
+<div class="sheet-col">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 35%;"><label>Character Name</label></div>
+<div class="sheet-item" style="width: 60%;"><input name="attr_character_name" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Homeworld</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_Homeworld" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Regiment</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_Regiment" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Speciality</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_Speciality" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Demeanour</label></div>
+<div class="sheet-item" style="width: 70%;"><input name="attr_Demeanour" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Notes</label></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_Notes" type="text" /></div>
+</div>
+</div>
+<!-- Mid Column (Logo) -->
+<div class="sheet-col">
+<h2>Only War</h2>
+<img src="https://41.media.tumblr.com/9c63660ca1d5fb6ddfb57338d2bfcb03/tumblr_ntwstyGU0y1s9slulo1_r2_500.png" alt="" /> <!--
         <img src="http://41.media.tumblr.com/tumblr_mb6ns23U621rue4a1o1_500.jpg">
-        -->  
-    </div>
-    
-    <!-- Right Column  -->   
-    <div class="sheet-col">
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:30%"><label>Player Name</label></div>
-            <div class="sheet-item" style="width:65%"><input name="attr_Player" type="text"></div>
-        </div>    
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:18%"><label>Gender</label></div>
-            <div class="sheet-item" style="width:18%"><input name="attr_Gender" type="text"></div>
-            <div class="sheet-item" style="width:10%"><label>Age</label></div>
-            <div class="sheet-item" style="width:10%"><input name="attr_Age" type="text"></div>
-            <div class="sheet-item" style="width:14%"><label>Build</label></div>
-            <div class="sheet-item" style="width:26%"><input name="attr_Build" type="text"></div>
-        </div> 
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:25%"><label>Complexion</label></div>
-            <div class="sheet-item" style="width:28%"><input name="attr_Complexion" type="text"></div>
-            <div class="sheet-item" style="width:12%"><label>Hair</label></div>
-            <div class="sheet-item" style="width:30%"><input name="attr_Hair" type="text"></div>
-        </div> 
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:18%"><label>Quirks</label></div>
-            <div class="sheet-item" style="width:77%"><input name="attr_Quirks" type="text"></div>
-        </div> 
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:18%"><label>Allies</label></div>
-            <div class="sheet-item" style="width:77%"><input name="attr_Allies" type="text"></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:20%"><label>Enemies</label></div>
-            <div class="sheet-item" style="width:75%"><input name="attr_Enemies" type="text"></div>
-        </div>
-    </div>
+        --></div>
+<!-- Right Column  -->
+<div class="sheet-col">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><label>Player Name</label></div>
+<div class="sheet-item" style="width: 65%;"><input name="attr_Player" type="text" /></div>
 </div>
-
-<!-- First Part = Characteristics\Experience&Fate\Insanity&Corruption\Skills -->
-<!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
-
+<div class="sheet-row">
+<div class="sheet-item" style="width: 18%;"><label>Gender</label></div>
+<div class="sheet-item" style="width: 18%;"><input name="attr_Gender" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><label>Age</label></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_Age" type="text" /></div>
+<div class="sheet-item" style="width: 14%;"><label>Build</label></div>
+<div class="sheet-item" style="width: 26%;"><input name="attr_Build" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Complexion</label></div>
+<div class="sheet-item" style="width: 28%;"><input name="attr_Complexion" type="text" /></div>
+<div class="sheet-item" style="width: 12%;"><label>Hair</label></div>
+<div class="sheet-item" style="width: 30%;"><input name="attr_Hair" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 18%;"><label>Quirks</label></div>
+<div class="sheet-item" style="width: 77%;"><input name="attr_Quirks" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 18%;"><label>Allies</label></div>
+<div class="sheet-item" style="width: 77%;"><input name="attr_Allies" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><label>Enemies</label></div>
+<div class="sheet-item" style="width: 75%;"><input name="attr_Enemies" type="text" /></div>
+</div>
+</div>
+</div>
+<!-- First Part = Characteristics\Experience&Fate\Insanity&Corruption\Skills --> <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+<div class="sheet-2colrow"><!-- Left Side -->
+<div class="sheet-col">
+<div class="sheet-characteristics">
+<h3>Characteristics</h3>
+<div class="sheet-2colrow"><!-- Left Column (Characteristics) -->
+<div class="sheet-col"><!-- WeaponSkill (WS) -->
 <div class="sheet-2colrow">
-
-    <!-- Left Side -->
-    <div class="sheet-col">
-        
-        <div class="sheet-characteristics">
-        <h3>Characteristics</h3>
-        <div class="sheet-2colrow">
-
-            <!-- Left Column (Characteristics) -->
-            <div class="sheet-col">
-            
-                <!-- WeaponSkill (WS) -->
-                <div class="sheet-2colrow">
-                    <div class="sheet-col">
-                        <button name="roll_WS" type="roll" value="/me Weapon Skill Target [[(@{WeaponSkill}+?{Modifier|0})]] Roll: [[1d100]]"><label>Weapon Skill (WS)</label></button>
-                    </div>
-                    <div class="sheet-col">
-                        <input name="attr_WeaponSkill" type="text" value="0">
-                    </div>
-                </div>
-                
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:10%"></div>
-                    <div class="sheet-item" style="width:80%">
-                        <select class="advanceselect" name="attr_advanceWS">
-                            <option value="0">None (0)</option>
-                            <option value="5">Simple (+5)</option>
-                            <option value="10">Intermediate (+10)</option>
-                            <option value="15">Trained (+15)</option>
-                            <option value="20">Expert (+20)</option>
-
-                        </select>
-                    </div>    
-                </div>
-
-                <!-- BallisticSkill (BS) -->
-                <div class="sheet-2colrow">
-                    <div class="sheet-col">
-                        <button name="roll_BS" type="roll" value="/me Ballistic Skill Target: [[(@{BallisticSkill}+?{Modifier|0})]] Roll: [[1d100]]"><label>Ballistic Skill (BS)</label></button>
-                    </div>
-                    <div class="sheet-col">
-                        <input name="attr_BallisticSkill" type="text" value="0">
-                    </div>
-                </div>
-                
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:10%"></div>
-                    <div class="sheet-item" style="width:80%">
-                        <select class="advanceselect" name="attr_advanceBS">
-                            <option value="0">None (0)</option>
-                            <option value="5">Simple (+5)</option>
-                            <option value="10">Intermediate (+10)</option>
-                            <option value="15">Trained (+15)</option>
-                            <option value="20">Expert (+20)</option>
-
-                        </select>
-                    </div>    
-                </div>
-                
-                <!-- Strength (S) -->
-                <div class="sheet-2colrow">
-                    <div class="sheet-col">
-                        <button name="roll_S" type="roll" value="/me Strength Target: [[(@{Strength}+?{Modifier|0})]] Roll: [[1d100]]"><label>Strength<br/>(S)</label></button>
-                    </div>
-                    <div class="sheet-col">
-                        <input name="attr_Strength" type="text" value="0">
-                    </div>
-                </div>
-
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:10%"></div>
-                    <div class="sheet-item" style="width:80%">
-                        <select class="advanceselect" name="attr_advanceS">
-                            <option value="0">None (0)</option>
-                            <option value="5">Simple (+5)</option>
-                            <option value="10">Intermediate (+10)</option>
-                            <option value="15">Trained (+15)</option>
-                            <option value="20">Expert (+20)</option>
-
-                        </select>
-                    </div>    
-                </div>
-
-                <!-- Toughness (T) -->
-                <div class="sheet-2colrow">
-                    <div class="sheet-col">
-                        <button name="roll_T" type="roll" value="/me Toughness Target: [[(@{Toughness}+?{Modifier|0})]] Roll: [[1d100]]"><label>Toughness (T)</label></button>
-                    </div>
-                    <div class="sheet-col">
-                        <input name="attr_Toughness" type="text" value="0">
-                    </div>
-                </div>
-
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:10%"></div>
-                    <div class="sheet-item" style="width:80%">
-                        <select class="advanceselect" name="attr_advanceT">
-                            <option value="0">None (0)</option>
-                            <option value="5">Simple (+5)</option>
-                            <option value="10">Intermediate (+10)</option>
-                            <option value="15">Trained (+15)</option>
-                            <option value="20">Expert (+20)</option>
-
-                        </select>
-                    </div>    
-                </div>
-
-                <!-- Agility (Ag) -->
-                <div class="sheet-2colrow">
-                    <div class="sheet-col">
-                        <button name="roll_Ag" type="roll" value="/me Agility Target: [[(@{Agility}+?{Modifier|0})]] Roll: [[1d100]]"><label>Agility <br/>(Ag)</label></button>
-                    </div>
-                    <div class="sheet-col">
-                        <input name="attr_Agility" type="text" value="0">
-                    </div>
-                </div>
-    
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:10%"></div>
-                    <div class="sheet-item" style="width:80%">
-                        <select class="advanceselect" name="attr_advanceAg">
-                            <option value="0">None (0)</option>
-                            <option value="5">Simple (+5)</option>
-                            <option value="10">Intermediate (+10)</option>
-                            <option value="15">Trained (+15)</option>
-                            <option value="20">Expert (+20)</option>
-
-                        </select>
-                    </div>    
-                </div>
-            </div>
-
-            <!-- Characteristics (Right Column) -->
-            <div class="sheet-col">
-                
-                <!-- Intelligence (Int) -->
-                <div class="sheet-2colrow">
-                    <div class="sheet-col">
-                        <button name="roll_Int" type="roll" value="/me Intelligence Target: [[(@{Intelligence}+?{Modifier|0})]] Roll: [[1d100]]"><label>Intelligence (Int)</label></button>
-                    </div>
-                    <div class="sheet-col">
-                        <input name="attr_Intelligence" type="text" value="0">
-                    </div>
-                </div>
-                
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:10%"></div>
-                    <div class="sheet-item" style="width:80%">
-                        <select class="advanceselect" name="attr_advanceInt">
-                            <option value="0">None (0)</option>
-                            <option value="5">Simple (+5)</option>
-                            <option value="10">Intermediate (+10)</option>
-                            <option value="15">Trained (+15)</option>
-                            <option value="20">Expert (+20)</option>
-
-                        </select>
-                    </div>    
-                </div>
-
-                <!-- Perception (Per) -->
-                <div class="sheet-2colrow">
-                    <div class="sheet-col">
-                        <button name="roll_Per" type="roll" value="/me Perception Target: [[(@{Perception}+?{Modifier|0})]] Roll: [[1d100]]"><label>Perception (Per)</label></button>
-                    </div>
-                    <div class="sheet-col">
-                        <input name="attr_Perception" type="text" value="0">
-                    </div>
-                </div>
-                
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:10%"></div>
-                    <div class="sheet-item" style="width:80%">
-                        <select class="advanceselect" name="attr_advancePer">
-                            <option value="0">None (0)</option>
-                            <option value="5">Simple (+5)</option>
-                            <option value="10">Intermediate (+10)</option>
-                            <option value="15">Trained (+15)</option>
-                            <option value="20">Expert (+20)</option>
-
-                        </select>
-                    </div>    
-                </div>
-
-                <!-- Willpower (WP) -->
-                <div class="sheet-2colrow">
-                    <div class="sheet-col">
-                        <button name="roll_WP" type="roll" value="/me Willpower Target: [[(@{Willpower}+?{Modifier|0})]] Roll: [[1d100]]"><label>Willpower (WP)</label></button>
-                    </div>
-                    <div class="sheet-col">
-                        <input name="attr_Willpower" type="text" value="0">
-                    </div>
-                </div>
-                
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:10%"></div>
-                    <div class="sheet-item" style="width:80%">
-                        <select class="advanceselect" name="attr_advanceWP">
-                            <option value="0">None (0)</option>
-                            <option value="5">Simple (+5)</option>
-                            <option value="10">Intermediate (+10)</option>
-                            <option value="15">Trained (+15)</option>
-                            <option value="20">Expert (+20)</option>
-
-                        </select>
-                    </div>    
-                </div>
-    
-                <!-- Fellowship (Fel) -->
-                <div class="sheet-2colrow">
-                    <div class="sheet-col">
-                        <button name="roll_Fel" type="roll" value="/me Fellowship Target: [[(@{Fellowship}+?{Modifier|0})]] Roll: [[1d100]]"><label>Fellowship (Fel)</label></button>
-                    </div>
-                    <div class="sheet-col">
-                        <input name="attr_Fellowship" type="text" value="0">
-                    </div>
-                </div>
-                
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:10%"></div>
-                    <div class="sheet-item" style="width:80%">
-                        <select class="advanceselect" name="attr_advanceFel">
-                            <option value="0">None (0)</option>
-                            <option value="5">Simple (+5)</option>
-                            <option value="10">Intermediate (+10)</option>
-                            <option value="15">Trained (+15)</option>
-                            <option value="20">Expert (+20)</option>
-
-                        </select>
-                    </div>    
-                </div>
-            </div>
-        </div>
-        </div>
-        
-        <br>
-        <!-- Left Column (Experience & Fate) -->
-        <div class="sheet-2colrow">
-            
-            <div class="sheet-col sheet-fate">
-                <h3>Experience</h3>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:5%"></div>
-                    <div class="sheet-item" style="width:55%">
-                        <label>XP to Spend</label>
-                    </div>
-                    <div class="sheet-item" style="width:40%">
-                        <input name="attr_XPtoSpend" type="number">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:5%"></div>
-                    <div class="sheet-item" style="width:55%">
-                        <label>Total XP Spent</label>
-                    </div>
-                    <div class="sheet-item" style="width:40%">
-                        <input name="attr_XPSpent" type="number">
-                    </div>
-                </div>
-            </div>
-    
-            <div class="sheet-col sheet-fate">
-                <h3>Fate Points</h3>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:50%">
-                        <label>Threshold</label>
-                    </div>
-                    <div class="sheet-item" style="width:20%">
-                        <input name="attr_Fate_max" type="number">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:50%">
-                        <label>Current</label>
-                    </div>
-                    <div class="sheet-item" style="width:20%">
-                        <input name="attr_Fate" type="number">
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <!-- Left Column (Insanity and Corruption) -->
-        <div class="sheet-2colrow">
-            <div class="sheet-col sheet-fate">
-                <h3>Insanity (Is)</h3>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:45%"></div>
-                    <div class="sheet-item" style="width:20%">
-                        <input name="attr_Insanity" type="number">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:25%"></div>
-                    <div class="sheet-item" style="width:60%"><label>Mental Disorders</label></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_1stDisorder" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_2ndDisorder" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_3rdDisorder" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_4thDisorder" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_5thDisorder" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_6thDisorder" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_7thDisorder" type="text">
-                    </div>
-                </div>
-                
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:5%"></div>
-                    <div class="sheet-item" style="width:13%"><label>WS</label></div>
-                    <div class="sheet-item" style="width:9%"><input name="attr_MutWS" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:13%"><label>BS</label></div>
-                    <div class="sheet-item" style="width:9%"><input name="attr_MutBS" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:7%"><label>S</label></div>
-                    <div class="sheet-item" style="width:9%"><input name="attr_MutS" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:7%"><label>T</label></div>
-                    <div class="sheet-item" style="width:9%"><input name="attr_MutT" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:11%"><label>Ag</label></div>
-                    <div class="sheet-item" style="width:9%"><input name="attr_MutAg" type="checkbox" value="1"></div>
-                </div>
-            </div>
-    
-            <div class="sheet-col sheet-fate">
-                <h3>Corruption (C)</h3>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:45%"></div>
-                    <div class="sheet-item" style="width:20%">
-                        <input name="attr_Corruption" type="number">
-                    </div>   
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:30%"></div>
-                    <div class="sheet-item" style="width:60%"><label>Malignancies</label></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_1stMalignancy" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_2ndMalignancy" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_3rdMalignancy" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:35%"></div>
-                    <div class="sheet-item" style="width:60%"><label>Mutations</label></div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_1stMutation" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_2ndMutation" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_3rdMutation" type="text">
-                    </div>
-                </div>
-                
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:13%"><label>Int</label></div>
-                    <div class="sheet-item" style="width:8%"><input name="attr_MutInt" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:13%"><label>Per</label></div>
-                    <div class="sheet-item" style="width:8%"><input name="attr_MutPer" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:13%"><label>WP</label></div>
-                    <div class="sheet-item" style="width:8%"><input name="attr_MutWP" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:11%"><label>Fel</label></div>
-                    <div class="sheet-item" style="width:8%"><input name="attr_MutFel" type="checkbox" value="1"></div>
-                    <div class="sheet-item" style="width:10%"><label>Ifl</label></div>
-                    <div class="sheet-item" style="width:8%"><input name="attr_MutIfl" type="checkbox" value="1"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-    
+<div class="sheet-col"><button name="roll_WS" type="roll" value="/em rolls Weapon Skill with [[ ([[@{WeaponSkill} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Weapon Skill (WS)</label></button></div>
+<div class="sheet-col"><input name="attr_WeaponSkill" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_advanceWS">
+<option value="0">None (0)</option>
+<option value="5">Simple (+5)</option>
+<option value="10">Intermediate (+10)</option>
+<option value="15">Trained (+15)</option>
+<option value="20">Expert (+20)</option>
+</select></div>
+</div>
+<!-- BallisticSkill (BS) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_BS" type="roll" value="/em rolls Ballistic Skill with [[ ([[@{BallisticSkill} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Ballistic Skill (BS)</label></button></div>
+<div class="sheet-col"><input name="attr_BallisticSkill" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_advanceBS">
+<option value="0">None (0)</option>
+<option value="5">Simple (+5)</option>
+<option value="10">Intermediate (+10)</option>
+<option value="15">Trained (+15)</option>
+<option value="20">Expert (+20)</option>
+</select></div>
+</div>
+<!-- Strength (S) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_S" type="roll" value="/em rolls Strength with [[ ([[@{Strength} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Strength<br />(S)</label></button></div>
+<div class="sheet-col"><input name="attr_Strength" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_advanceS">
+<option value="0">None (0)</option>
+<option value="5">Simple (+5)</option>
+<option value="10">Intermediate (+10)</option>
+<option value="15">Trained (+15)</option>
+<option value="20">Expert (+20)</option>
+</select></div>
+</div>
+<!-- Toughness (T) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_T" type="roll" value="/em rolls Toughness with [[ ([[@{Toughness} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Toughness (T)</label></button></div>
+<div class="sheet-col"><input name="attr_Toughness" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_advanceT">
+<option value="0">None (0)</option>
+<option value="5">Simple (+5)</option>
+<option value="10">Intermediate (+10)</option>
+<option value="15">Trained (+15)</option>
+<option value="20">Expert (+20)</option>
+</select></div>
+</div>
+<!-- Agility (Ag) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Ag" type="roll" value="/em rolls Agility with [[ ([[@{Agility} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Agility <br />(Ag)</label></button></div>
+<div class="sheet-col"><input name="attr_Agility" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_advanceAg">
+<option value="0">None (0)</option>
+<option value="5">Simple (+5)</option>
+<option value="10">Intermediate (+10)</option>
+<option value="15">Trained (+15)</option>
+<option value="20">Expert (+20)</option>
+</select></div>
+</div>
+</div>
+<!-- Characteristics (Right Column) -->
+<div class="sheet-col"><!-- Intelligence (Int) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Int" type="roll" value="/em rolls Intelligence with [[ ([[@{Intelligence} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Intelligence (Int)</label></button></div>
+<div class="sheet-col"><input name="attr_Intelligence" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_advanceInt">
+<option value="0">None (0)</option>
+<option value="5">Simple (+5)</option>
+<option value="10">Intermediate (+10)</option>
+<option value="15">Trained (+15)</option>
+<option value="20">Expert (+20)</option>
+</select></div>
+</div>
+<!-- Perception (Per) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Per" type="roll" value="/em rolls Perception with [[ ([[@{Perception} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Perception (Per)</label></button></div>
+<div class="sheet-col"><input name="attr_Perception" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_advancePer">
+<option value="0">None (0)</option>
+<option value="5">Simple (+5)</option>
+<option value="10">Intermediate (+10)</option>
+<option value="15">Trained (+15)</option>
+<option value="20">Expert (+20)</option>
+</select></div>
+</div>
+<!-- Willpower (WP) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_WP" type="roll" value="/em rolls Willpower with [[ ([[@{Willpower} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Willpower (WP)</label></button></div>
+<div class="sheet-col"><input name="attr_Willpower" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_advanceWP">
+<option value="0">None (0)</option>
+<option value="5">Simple (+5)</option>
+<option value="10">Intermediate (+10)</option>
+<option value="15">Trained (+15)</option>
+<option value="20">Expert (+20)</option>
+</select></div>
+</div>
+<!-- Fellowship (Fel) -->
+<div class="sheet-2colrow">
+<div class="sheet-col"><button name="roll_Fel" type="roll" value="/em rolls Fellowship with [[ ([[@{Fellowship} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"><label>Fellowship (Fel)</label></button></div>
+<div class="sheet-col"><input name="attr_Fellowship" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 10%;">&nbsp;</div>
+<div class="sheet-item" style="width: 80%;"><select class="advanceselect" name="attr_advanceFel">
+<option value="0">None (0)</option>
+<option value="5">Simple (+5)</option>
+<option value="10">Intermediate (+10)</option>
+<option value="15">Trained (+15)</option>
+<option value="20">Expert (+20)</option>
+</select></div>
+</div>
+</div>
+</div>
+</div>
+<br /> <!-- Left Column (Experience & Fate) -->
+<div class="sheet-2colrow">
+<div class="sheet-col sheet-fate">
+<h3>Experience</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 55%;"><label>XP to Spend</label></div>
+<div class="sheet-item" style="width: 40%;"><input name="attr_XPtoSpend" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 55%;"><label>Total XP Spent</label></div>
+<div class="sheet-item" style="width: 40%;"><input name="attr_XPSpent" type="number" /></div>
+</div>
+</div>
+<div class="sheet-col sheet-fate">
+<h3>Fate Points</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;"><label>Threshold</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Fate_max" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 50%;"><label>Current</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Fate" type="number" /></div>
+</div>
+</div>
+</div>
+<!-- Left Column (Insanity and Corruption) -->
+<div class="sheet-2colrow">
+<div class="sheet-col sheet-fate">
+<h3>Insanity (Is)</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 45%;">&nbsp;</div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Insanity" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;">&nbsp;</div>
+<div class="sheet-item" style="width: 60%;"><label>Mental Disorders</label></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_1stDisorder" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_2ndDisorder" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_3rdDisorder" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_4thDisorder" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_5thDisorder" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_6thDisorder" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_7thDisorder" type="text" /></div>
+</div>
+<h3>Unnatural</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 5%;">&nbsp;</div>
+<div class="sheet-item" style="width: 13%;"><label>WS</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_MutWS" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 13%;"><label>BS</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_MutBS" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 7%;"><label>S</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_MutS" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 7%;"><label>T</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_MutT" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 11%;"><label>Ag</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_MutAg" type="number" value="0" /></div>
+</div>
+</div>
+<div class="sheet-col sheet-fate">
+<h3>Corruption (C)</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 45%;">&nbsp;</div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Corruption" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;">&nbsp;</div>
+<div class="sheet-item" style="width: 60%;"><label>Malignancies</label></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_1stMalignancy" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_2ndMalignancy" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_3rdMalignancy" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 35%;">&nbsp;</div>
+<div class="sheet-item" style="width: 60%;"><label>Mutations</label></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_1stMutation" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_2ndMutation" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_3rdMutation" type="text" /></div>
+</div>
+<h3>Characteristics</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 13%;"><label>Int</label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_MutInt" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 13%;"><label>Per</label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_MutPer" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 13%;"><label>Wil</label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_MutWP" type="number" value="0" /></div>
+<div class="sheet-item" style="width: 11%;"><label>Fel</label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_MutFel" type="number" value="0" /></div>
+</div>
+</div>
+</div>
+</div>
 <!-- Right Side -->
-    <div class="sheet-col">
-        
-        <!-- Right Column (Skills) -->
-        <h3>Skills</h3>
-        <div class="sheet-2colrow">
-            
-            <div class="sheet-col sheet-skills">
-                <table>
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Acrobatics" type="roll" 
-                                    value="/em rolls Acrobatics with [[ ([[@{AcrobaticsCharacteristic} + -20 + @{Acrobatics1} + @{Acrobatics2} + @{Acrobatics3} + @{Acrobatics4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                <label>Acrobatics</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_AcrobaticsCharacteristic">
-                                    <option value="@{Agility}">(Ag)</option>
-                                    <option value="@{Strength}">(S)</option>
-                                    </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Acrobatics1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Acrobatics2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Acrobatics3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Acrobatics4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Athletics" type="roll" 
-                                    value="/em rolls Athletics with [[ ([[@{AthleticsCharacteristic} + -20 + @{Athletics1} + @{Athletics2} + @{Athletics3} + @{Athletics4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Athletics</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_AthleticsCharacteristic">
-                                    <option value="@{Strength}">(S)</option>
-                                    <option value="@{Toughness}">(T)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Athletics1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Athletics2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Athletics3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Athletics4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Awareness" type="roll" 
-                                    value="/em rolls Awareness with [[ ([[@{AwarenessCharacteristic} + -20 + @{Awareness1} + @{Awareness2} + @{Awareness3} + @{Awareness4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Awareness</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_AwarenessCharacteristic">
-                                    <option value="@{Perception}">(Per)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                    <option value="@{Intelligence}">(Int)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Awareness1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Awareness2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Awareness3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Awareness4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Charm" type="roll" 
-                                    value="/em rolls Charm with [[ ([[@{CharmCharacteristic} + -20 + @{Charm1} + @{Charm2} + @{Charm3} + @{Charm4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Charm</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_CharmCharacteristic">
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                    <option value="@{Influence}">(Ifl)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Charm1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Charm2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Charm3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Charm4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Command" type="roll" 
-                                    value="/em rolls Command with [[ ([[@{CommandCharacteristic} + -20 + @{Command1} + @{Command2} + @{Command3} + @{Command4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Command</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_CommandCharacteristic">
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Strength}">(S)</option>
-                                    <option value="@{Willpower}">(WP)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Command1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Command2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Command3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Command4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Commerce" type="roll" 
-                                    value="/em rolls Commerce with [[ ([[@{CommerceCharacteristic} + -20 + @{Commerce1} + @{Commerce2} + @{Commerce3} + @{Commerce4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Commerce</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_CommerceCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Commerce1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Commerce2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Commerce3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Commerce4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Deceive" type="roll" 
-                                    value="/em rolls Deceive with [[ ([[@{DeceiveCharacteristic} + -20 + @{Deceive1} + @{Deceive2} + @{Deceive3} + @{Deceive4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Deceive</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_DeceiveCharacteristic">
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                    <option value="@{Intelligence}">(Int)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Deceive1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Deceive2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Deceive3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Deceive4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Dodge" type="roll" 
-                                    value="/em rolls Dodge with [[ ([[@{DodgeCharacteristic} + -20 + @{Dodge1} + @{Dodge2} + @{Dodge3} + @{Dodge4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Dodge</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_DodgeCharacteristic">
-                                    <option value="@{Agility}">(Ag)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Dodge1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Dodge2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Dodge3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Dodge4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Inquiry" type="roll" 
-                                    value="/em rolls Inquiry with [[ ([[@{InquiryCharacteristic} + -20 + @{Inquiry1} + @{Inquiry2} + @{Inquiry3} + @{Inquiry4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Inquiry</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_InquiryCharacteristic">
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Perception}">(Per)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Inquiry1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Inquiry2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Inquiry3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Inquiry4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Interrogation" type="roll" 
-                                    value="/em rolls Interrogation with [[ ([[@{InterrogationCharacteristic} + -20 + @{Interrogation1} + @{Interrogation2} + @{Interrogation3} + @{Interrogation4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Interrogation</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_InterrogationCharacteristic">
-                                    <option value="@{Willpower}">(WP)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Interrogation1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Interrogation2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Interrogation3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Interrogation4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Intimidate" type="roll" 
-                                    value="/em rolls Intimidate with [[ ([[@{IntimidateCharacteristic} + -20 + @{Intimidate1} + @{Intimidate2} + @{Intimidate3} + @{Intimidate4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Intimidate</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_IntimidateCharacteristic">
-                                    <option value="@{Strength}">(S)</option>
-                                    <option value="@{Willpower}">(WP)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Intimidate1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Intimidate2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Intimidate3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Intimidate4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Logic" type="roll" 
-                                    value="/em rolls Logic with [[ ([[@{LogicCharacteristic} + -20 + @{Logic1} + @{Logic2} + @{Logic3} + @{Logic4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Logic</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_LogicCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Agility}">(Ag)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Logic1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Logic2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Logic3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Logic4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Medicae" type="roll" 
-                                    value="/em rolls Medicae with [[ ([[@{MedicaeCharacteristic} + -20 + @{Medicae1} + @{Medicae2} + @{Medicae3} + @{Medicae4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Medicae</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_MedicaeCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Agility}">(Ag)</option>
-                                    <option value="@{Perception}">(Per)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Medicae1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Medicae2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Medicae3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Medicae4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%"><label>Navigate</label></div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_NavigateCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Perception}">(Per)</option>
-                                </select>
-                            </div>
-                        </div>    
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:100%">
-                                <button name="roll_Surface" type="roll" 
-                                    value="/em rolls Navigate (Surface) with [[ ([[@{NavigateCharacteristic} + -20 + @{Surface1} + @{Surface2} + @{Surface3} + @{Surface4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Surface</label>
-                                </button>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Surface1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Surface2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Surface3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Surface4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:100%">
-                                <button name="roll_Stellar" type="roll" 
-                                    value="/em rolls Navigate (Stellar) with [[ ([[@{NavigateCharacteristic} + -20 + @{Stellar1} + @{Stellar2} + @{Stellar3} + @{Stellar4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Stellar</label>
-                                </button>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Stellar1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Stellar2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Stellar3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Stellar4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:100%">
-                                <button name="roll_Warp" type="roll" 
-                                    value="/em rolls Navigate (Warp) with [[ ([[@{NavigateCharacteristic} + -20 + @{Warp1} + @{Warp2} + @{Warp3} + @{Warp4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Warp</label>
-                                </button>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Warp1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Warp2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Warp3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Warp4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%"><label>Operate</label></div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_OperateCharacteristic">
-                                    <option value="@{Agility}">(Ag)</option>
-                                    <option value="@{Intelligence}">(Int)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:100%">
-                                <button name="roll_Aeronautica" type="roll" 
-                                    value="/em rolls Operate (Aeronautica) with [[ ([[@{OperateCharacteristic} + -20 + @{Aeronautica1} + @{Aeronautica2} + @{Aeronautica3} + @{Aeronautica4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Aeronautica</label>
-                                </button>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Aeronautica1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Aeronautica2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Aeronautica3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Aeronautica4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:100%">
-                                <button name="roll_OSurface" type="roll" 
-                                    value="/em rolls Operate (Surface) with [[ ([[@{OperateCharacteristic} + -20 + @{OSurface1} + @{OSurface2} + @{OSurface3} + @{OSurface4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Surface</label>
-                                </button>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_OSurface1" type="checkbox" value="20"></td>
-                        <td><input name="attr_OSurface2" type="checkbox" value="10"></td>
-                        <td><input name="attr_OSurface3" type="checkbox" value="10"></td>
-                        <td><input name="attr_OSurface4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:100%">
-                                <button name="roll_Voidship" type="roll" 
-                                    value="/em rolls Operate (Voidship) with [[ ([[@{OperateCharacteristic} + -20 + @{Voidship1} + @{Voidship2} + @{Voidship3} + @{Voidship4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Voidship</label>
-                                </button>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Voidship1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Voidship2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Voidship3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Voidship4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Parry" type="roll" 
-                                    value="/em rolls Parry with [[ ([[@{ParryCharacteristic} + -20 + @{Parry1} + @{Parry2} + @{Parry3} + @{Parry4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Parry</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_ParryCharacteristic">
-                                    <option value="@{WeaponSkill}">(WS)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Parry1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Parry2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Parry3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Parry4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Psyniscience" type="roll" 
-                                    value="/em rolls Psyniscience with [[ ([[@{PsyniscienceCharacteristic} + -20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Psyniscience</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_PsyniscienceCharacteristic">
-                                    <option value="@{Perception}">(Per)</option>
-                                    <option value="@{Willpower}">(WP)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Psyniscience1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Psyniscience2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Psyniscience3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Psyniscience4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Scrutiny" type="roll" 
-                                    value="/em rolls Scrutiny with [[ ([[@{ScrutinyCharacteristic} + -20 + @{Scrutiny1} + @{Scrutiny2} + @{Scrutiny3} + @{Scrutiny4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Scrutiny</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_ScrutinyCharacteristic">
-                                    <option value="@{Perception}">(Per)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Scrutiny1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Scrutiny2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Scrutiny3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Scrutiny4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Security" type="roll" 
-                                    value="/em rolls Security with [[ ([[@{SecurityCharacteristic} + -20 + @{Security1} + @{Security2} + @{Security3} + @{Security4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Security</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_SecurityCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Agility}">(Ag)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Security1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Security2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Security3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Security4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_SleightOfHand" type="roll" 
-                                    value="/em rolls SleightOfHand with [[ ([[@{SleightOfHandCharacteristic} + -20 + @{SleightOfHand1} + @{SleightOfHand2} + @{SleightOfHand3} + @{SleightOfHand4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>SleightOfHand</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_SleightOfHandCharacteristic">
-                                    <option value="@{Agility}">(Ag)</option>
-                                    <option value="@{Intelligence}">(Int)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_SleightOfHand1" type="checkbox" value="20"></td>
-                        <td><input name="attr_SleightOfHand2" type="checkbox" value="10"></td>
-                        <td><input name="attr_SleightOfHand3" type="checkbox" value="10"></td>
-                        <td><input name="attr_SleightOfHand4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Stealth" type="roll" 
-                                    value="/em rolls Stealth with [[ ([[@{StealthCharacteristic} + -20 + @{Stealth1} + @{Stealth2} + @{Stealth3} + @{Stealth4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Stealth</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_StealthCharacteristic">
-                                    <option value="@{Agility}">(Ag)</option>
-                                    <option value="@{Perception}">(Per)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Stealth1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Stealth2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Stealth3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Stealth4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_Survival" type="roll" 
-                                    value="/em rolls Survival with [[ ([[@{SurvivalCharacteristic} + -20 + @{Survival1} + @{Survival2} + @{Survival3} + @{Survival4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Survival</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_SurvivalCharacteristic">
-                                    <option value="@{Perception}">(Per)</option>
-                                    <option value="@{Agility}">(Ag)</option>
-                                    <option value="@{Intelligence}">(Int)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_Survival1" type="checkbox" value="20"></td>
-                        <td><input name="attr_Survival2" type="checkbox" value="10"></td>
-                        <td><input name="attr_Survival3" type="checkbox" value="10"></td>
-                        <td><input name="attr_Survival4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:55%">
-                                <button name="roll_TechUse" type="roll" 
-                                    value="/em rolls Tech-Use with [[ ([[@{TechUseCharacteristic} + -20 + @{TechUse1} + @{TechUse2} + @{TechUse3} + @{TechUse4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                    <label>Tech-Use</label>
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:45%">
-                                <select class="charaselect" name="attr_TechUseCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Agility}">(Ag)</option>
-                                </select>
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_TechUse1" type="checkbox" value="20"></td>
-                        <td><input name="attr_TechUse2" type="checkbox" value="10"></td>
-                        <td><input name="attr_TechUse3" type="checkbox" value="10"></td>
-                        <td><input name="attr_TechUse4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                </table>
-            </div>
-            
-            <div class="sheet-col sheet-skills">
-                <table>
-                
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:60%"><label>Linguistics</label></div>
-                            <div class="sheet-item" style="width:40%">
-                                <select class="charaselect" name="attr_LinguisticsCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                </select>
-                            </div>
-                        </div>    
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_1stLanguage" type="roll" 
-                                    value="/em rolls @{1stLanguage} with [[ ([[@{LinguisticsCharacteristic} + -20 + @{1stLanguage1} + @{1stLanguage2} + @{1stLanguage3} + @{1stLanguage4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_1stLanguage" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_1stLanguage1" type="checkbox" value="20"></td>
-                        <td><input name="attr_1stLanguage2" type="checkbox" value="10"></td>
-                        <td><input name="attr_1stLanguage3" type="checkbox" value="10"></td>
-                        <td><input name="attr_1stLanguage4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_2ndLanguage" type="roll" 
-                                    value="/em rolls @{2ndLanguage} with [[ ([[@{LinguisticsCharacteristic} + -20 + @{2ndLanguage1} + @{2ndLanguage2} + @{2ndLanguage3} + @{2ndLanguage4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_2ndLanguage" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_2ndLanguage1" type="checkbox" value="20"></td>
-                        <td><input name="attr_2ndLanguage2" type="checkbox" value="10"></td>
-                        <td><input name="attr_2ndLanguage3" type="checkbox" value="10"></td>
-                        <td><input name="attr_2ndLanguage4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_3rdLanguage" type="roll" 
-                                    value="/em rolls @{3rdLanguage} with [[ ([[@{LinguisticsCharacteristic} + -20 + @{3rdLanguage1} + @{3rdLanguage2} + @{3rdLanguage3} + @{3rdLanguage4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_3rdLanguage" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_3rdLanguage1" type="checkbox" value="20"></td>
-                        <td><input name="attr_3rdLanguage2" type="checkbox" value="10"></td>
-                        <td><input name="attr_3rdLanguage3" type="checkbox" value="10"></td>
-                        <td><input name="attr_3rdLanguage4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <!-- ====================== Trade ====================== -->
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:60%"><label>Trade</label></div>
-                            <div class="sheet-item" style="width:40%">
-                                <select class="charaselect" name="attr_TradeCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Agility}">(Ag)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                </select>
-                            </div>
-                        </div>    
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_1stTrade" type="roll" 
-                                    value="/em rolls @{1stTrade} with [[ ([[@{TradeCharacteristic} + -20 + @{1stTrade1} + @{1stTrade2} + @{1stTrade3} + @{1stTrade4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_1stTrade" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_1stTrade1" type="checkbox" value="20"></td>
-                        <td><input name="attr_1stTrade2" type="checkbox" value="10"></td>
-                        <td><input name="attr_1stTrade3" type="checkbox" value="10"></td>
-                        <td><input name="attr_1stTrade4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_2ndTrade" type="roll" 
-                                    value="/em rolls @{2ndTrade} with [[ ([[@{TradeCharacteristic} + -20 + @{2ndTrade1} + @{2ndTrade2} + @{2ndTrade3} + @{2ndTrade4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_2ndTrade" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_2ndTrade1" type="checkbox" value="20"></td>
-                        <td><input name="attr_2ndTrade2" type="checkbox" value="10"></td>
-                        <td><input name="attr_2ndTrade3" type="checkbox" value="10"></td>
-                        <td><input name="attr_2ndTrade4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_3rdTrade" type="roll" 
-                                    value="/em rolls @{3rdTrade} with [[ ([[@{TradeCharacteristic} + -20 + @{3rdTrade1} + @{3rdTrade2} + @{3rdTrade3} + @{3rdTrade4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_3rdTrade" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_3rdTrade1" type="checkbox" value="20"></td>
-                        <td><input name="attr_3rdTrade2" type="checkbox" value="10"></td>
-                        <td><input name="attr_3rdTrade3" type="checkbox" value="10"></td>
-                        <td><input name="attr_3rdTrade4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_4thTrade" type="roll" 
-                                    value="/em rolls @{4thTrade} with [[ ([[@{TradeCharacteristic} + -20 + @{4thTrade1} + @{4thTrade2} + @{4thTrade3} + @{4thTrade4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_4thTrade" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_4thTrade1" type="checkbox" value="20"></td>
-                        <td><input name="attr_4thTrade2" type="checkbox" value="10"></td>
-                        <td><input name="attr_4thTrade3" type="checkbox" value="10"></td>
-                        <td><input name="attr_4thTrade4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <!-- ====================== Lore ====================== -->
-                    <tr><td><label>Lore</label></td></tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:60%"><label>Common</label></div>
-                            <div class="sheet-item" style="width:40%">
-                                <select class="charaselect" name="attr_CommonLoreCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                </select>
-                            </div>
-                        </div>    
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_1stCommon" type="roll" 
-                                    value="/em rolls @{1stCommon} with [[ ([[@{CommonLoreCharacteristic} + -20 + @{1stCommon1} + @{1stCommon2} + @{1stCommon3} + @{1stCommon4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_1stCommon" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_1stCommon1" type="checkbox" value="20"></td>
-                        <td><input name="attr_1stCommon2" type="checkbox" value="10"></td>
-                        <td><input name="attr_1stCommon3" type="checkbox" value="10"></td>
-                        <td><input name="attr_1stCommon4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_2ndCommon" type="roll" 
-                                    value="/em rolls @{2ndCommon} with [[ ([[@{CommonLoreCharacteristic} + -20 + @{2ndCommon1} + @{2ndCommon2} + @{2ndCommon3} + @{2ndCommon4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_2ndCommon" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_2ndCommon1" type="checkbox" value="20"></td>
-                        <td><input name="attr_2ndCommon2" type="checkbox" value="10"></td>
-                        <td><input name="attr_2ndCommon3" type="checkbox" value="10"></td>
-                        <td><input name="attr_2ndCommon4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_3rdCommon" type="roll" 
-                                    value="/em rolls @{3rdCommon} with [[ ([[@{CommonLoreCharacteristic} + -20 + @{3rdCommon1} + @{3rdCommon2} + @{3rdCommon3} + @{3rdCommon4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_3rdCommon" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_3rdCommon1" type="checkbox" value="20"></td>
-                        <td><input name="attr_3rdCommon2" type="checkbox" value="10"></td>
-                        <td><input name="attr_3rdCommon3" type="checkbox" value="10"></td>
-                        <td><input name="attr_3rdCommon4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_4thCommon" type="roll" 
-                                    value="/em rolls @{4thCommon} with [[ ([[@{CommonLoreCharacteristic} + -20 + @{4thCommon1} + @{4thCommon2} + @{4thCommon3} + @{4thCommon4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_4thCommon" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_4thCommon1" type="checkbox" value="20"></td>
-                        <td><input name="attr_4thCommon2" type="checkbox" value="10"></td>
-                        <td><input name="attr_4thCommon3" type="checkbox" value="10"></td>
-                        <td><input name="attr_4thCommon4" type="checkbox" value="10"></td>
-                    </tr>
-                        
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:60%"><label>Scholastic</label></div>
-                            <div class="sheet-item" style="width:40%">
-                                <select class="charaselect" name="attr_ScholasticLoreCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                </select>
-                            </div>
-                        </div>    
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_1stScholastic" type="roll" 
-                                    value="/em rolls @{1stScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{1stScholastic1} + @{1stScholastic2} + @{1stScholastic3} + @{1stScholastic4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_1stScholastic" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_1stScholastic1" type="checkbox" value="20"></td>
-                        <td><input name="attr_1stScholastic2" type="checkbox" value="10"></td>
-                        <td><input name="attr_1stScholastic3" type="checkbox" value="10"></td>
-                        <td><input name="attr_1stScholastic4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_2ndScholastic" type="roll" 
-                                    value="/em rolls @{2ndScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{2ndScholastic1} + @{2ndScholastic2} + @{2ndScholastic3} + @{2ndScholastic4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_2ndScholastic" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_2ndScholastic1" type="checkbox" value="20"></td>
-                        <td><input name="attr_2ndScholastic2" type="checkbox" value="10"></td>
-                        <td><input name="attr_2ndScholastic3" type="checkbox" value="10"></td>
-                        <td><input name="attr_2ndScholastic4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_3rdScholastic" type="roll" 
-                                    value="/em rolls @{3rdScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{3rdScholastic1} + @{3rdScholastic2} + @{3rdScholastic3} + @{3rdScholastic4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_3rdScholastic" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_3rdScholastic1" type="checkbox" value="20"></td>
-                        <td><input name="attr_3rdScholastic2" type="checkbox" value="10"></td>
-                        <td><input name="attr_3rdScholastic3" type="checkbox" value="10"></td>
-                        <td><input name="attr_3rdScholastic4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_4thScholastic" type="roll" 
-                                    value="/em rolls @{4thScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{4thScholastic1} + @{4thScholastic2} + @{4thScholastic3} + @{4thScholastic4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_4thScholastic" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_4thScholastic1" type="checkbox" value="20"></td>
-                        <td><input name="attr_4thScholastic2" type="checkbox" value="10"></td>
-                        <td><input name="attr_4thScholastic3" type="checkbox" value="10"></td>
-                        <td><input name="attr_4thScholastic4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_5thScholastic" type="roll" 
-                                    value="/em rolls @{5thScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{5thScholastic1} + @{5thScholastic2} + @{5thScholastic3} + @{5thScholastic4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_5thScholastic" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_5thScholastic1" type="checkbox" value="20"></td>
-                        <td><input name="attr_5thScholastic2" type="checkbox" value="10"></td>
-                        <td><input name="attr_5thScholastic3" type="checkbox" value="10"></td>
-                        <td><input name="attr_5thScholastic4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_6thScholastic" type="roll" 
-                                    value="/em rolls @{6thScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{6thScholastic1} + @{6thScholastic2} + @{6thScholastic3} + @{6thScholastic4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_6thScholastic" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_6thScholastic1" type="checkbox" value="20"></td>
-                        <td><input name="attr_6thScholastic2" type="checkbox" value="10"></td>
-                        <td><input name="attr_6thScholastic3" type="checkbox" value="10"></td>
-                        <td><input name="attr_6thScholastic4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:60%"><label>Forbidden</label></div>
-                            <div class="sheet-item" style="width:40%">
-                                <select class="charaselect" name="attr_ForbiddenLoreCharacteristic">
-                                    <option value="@{Intelligence}">(Int)</option>
-                                    <option value="@{Fellowship}">(Fel)</option>
-                                </select>
-                            </div>
-                        </div>    
-                        </td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_1stForbidden" type="roll" 
-                                    value="/em rolls @{1stForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{1stForbidden1} + @{1stForbidden2} + @{1stForbidden3} + @{1stForbidden4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_1stForbidden" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_1stForbidden1" type="checkbox" value="20"></td>
-                        <td><input name="attr_1stForbidden2" type="checkbox" value="10"></td>
-                        <td><input name="attr_1stForbidden3" type="checkbox" value="10"></td>
-                        <td><input name="attr_1stForbidden4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_2ndForbidden" type="roll" 
-                                    value="/em rolls @{2ndForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{2ndForbidden1} + @{2ndForbidden2} + @{2ndForbidden3} + @{2ndForbidden4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_2ndForbidden" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_2ndForbidden1" type="checkbox" value="20"></td>
-                        <td><input name="attr_2ndForbidden2" type="checkbox" value="10"></td>
-                        <td><input name="attr_2ndForbidden3" type="checkbox" value="10"></td>
-                        <td><input name="attr_2ndForbidden4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_3rdForbidden" type="roll" 
-                                    value="/em rolls @{3rdForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{3rdForbidden1} + @{3rdForbidden2} + @{3rdForbidden3} + @{3rdForbidden4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_3rdForbidden" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_3rdForbidden1" type="checkbox" value="20"></td>
-                        <td><input name="attr_3rdForbidden2" type="checkbox" value="10"></td>
-                        <td><input name="attr_3rdForbidden3" type="checkbox" value="10"></td>
-                        <td><input name="attr_3rdForbidden4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_4thForbidden" type="roll" 
-                                    value="/em rolls @{4thForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{4thForbidden1} + @{4thForbidden2} + @{4thForbidden3} + @{4thForbidden4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_4thForbidden" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_4thForbidden1" type="checkbox" value="20"></td>
-                        <td><input name="attr_4thForbidden2" type="checkbox" value="10"></td>
-                        <td><input name="attr_4thForbidden3" type="checkbox" value="10"></td>
-                        <td><input name="attr_4thForbidden4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_5thForbidden" type="roll" 
-                                    value="/em rolls @{5thForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{5thForbidden1} + @{5thForbidden2} + @{5thForbidden3} + @{5thForbidden4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_5thForbidden" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_5thForbidden1" type="checkbox" value="20"></td>
-                        <td><input name="attr_5thForbidden2" type="checkbox" value="10"></td>
-                        <td><input name="attr_5thForbidden3" type="checkbox" value="10"></td>
-                        <td><input name="attr_5thForbidden4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                    <tr>
-                        <td>
-                        <div class="sheet-row">
-                            <div class="sheet-item" style="width:20%">
-                                <button name="roll_6thForbidden" type="roll" 
-                                    value="/em rolls @{6thForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{6thForbidden1} + @{6thForbidden2} + @{6thForbidden3} + @{6thForbidden4} + ?{Modifier|0}]]-1d100)/10]] degree(s) of success!">
-                                </button>
-                            </div>
-                            <div class="sheet-item" style="width:80%">
-                                <input name="attr_6thForbidden" type="text">
-                            </div>
-                        </div>
-                        </td>
-                        <td><input name="attr_6thForbidden1" type="checkbox" value="20"></td>
-                        <td><input name="attr_6thForbidden2" type="checkbox" value="10"></td>
-                        <td><input name="attr_6thForbidden3" type="checkbox" value="10"></td>
-                        <td><input name="attr_6thForbidden4" type="checkbox" value="10"></td>
-                    </tr>
-                    
-                </table>
-            </div>   
-        </div>
-    </div>  
-</div>
-
-
-<!-- Second Part = Aptitudes\Talents&Traits\Melee&Raged Weapons -->
-<br>
-<!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
-
+<div class="sheet-col"><!-- Right Column (Skills) -->
+<h3>Skills</h3>
 <div class="sheet-2colrow">
-    <div class="sheet-col">
-        <h3>Aptitudes</h3>
-        <div class="sheet-2colrow">
-            <div class="sheet-col">
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_1stAptitude" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_2ndAptitude" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_3rdAptitude" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_4thAptitude" type="text">
-                    </div>
-                </div>
-            </div>
-            <div class="sheet-col">
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_5thAptitude" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_6thAptitude" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_7thAptitude" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_8thAptitude" type="text">
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <br>
-        
-        <h3>Melee Weapons</h3>
-        <fieldset class="repeating_meleeweapons">
-        <div class="sheet-quickborder">
-            <div class="sheet-row">
-                <div class="sheet-item" style="width:15%">
-                    <label>Name:</label>
-                </div>
-                <div class="sheet-item" style="width:55%">
-                    <input name="attr_meleeweaponname" type="text">
-                </div>
-                <div class="sheet-item" style="width:12%">
-                    <label>Class:</label>
-                </div>
-                <div class="sheet-item" style="width:19%">
-                    <input name="attr_meleeweaponclass" type="text">
-                </div>
-            </div>
-    
-            <div class="sheet-row">
-                <div class="sheet-item" style="width:15%">
-                    <label>Damage:</label>
-                </div>
-                <div class="sheet-item" style="width:20%">
-                    <input name="attr_meleeweapondamage" type="text">
-                </div>
-                <div class="sheet-item" style="width:12%">
-                    <label>Type:</label>
-                </div>
-                <div class="sheet-item" style="width:18%">
-                    <input name="attr_meleeweapontype" type="text">
-                </div>
-                <div class="sheet-item" style="width:10%">
-                    <label>Pen:</label>
-                </div>
-                <div class="sheet-item" style="width:10%">
-                    <input name="attr_meleeweaponpen" type="text" value="0">
-                </div>
-                <div class="sheet-item" style="width:16%">
-                    <button name="roll_meleedamage" type="roll" value="/me does [[@{meleeweapondamage}+(floor(@{strength}/10))]] @{meleeweapontype} damage! (Pen: @{meleeweaponpen})">
-                        <label>Damage</label>
-                    </button>
-                </div>
-            </div>
-    
-            <div class="sheet-row">
-                <div class="sheet-item" style="width:15%">
-                    <label>Special:</label>
-                </div>
-                <div class="sheet-item" style="width:75%">
-                    <input name="attr_meleeweaponspecial" type="text">
-                </div>
-                <div class="sheet-item" style="width:10%">
-                    <button name="roll_meleehit" type="roll" value="/me uses @{meleeweaponname} Roll: [[ (([[@{WeaponSkill}]] + ?{Modifier|0}) -1d100)/10]] degree(s) of success!">
-                        <label>Hit</label>
-                    </button>
-                </div>
-            </div>
-        </div>
-        </fieldset>
-        
-        <h3>Movement</h3>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:20%">
-                <label>Half Move: </label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_HalfMove" type="number" value="floor(@{Agility}/10)">
-            </div>
-            <div class="sheet-item" style="width:20%">
-                <label>Full Move: </label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_FullMove" type="number" value="2*(floor(@{Agility}/10))">
-            </div>
-            <div class="sheet-item" style="width:16%">
-                <label>Charge: </label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_ChargeMove" type="number" value="3*(floor(@{Agility}/10))">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <label>Run: </label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_RunMove" type="number" value="6*(floor(@{Agility}/10))">
-            </div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:28%">
-                <label>Fatigue</label>
-            </div>
-            <div class="sheet-item" style="width:20%">
-                <label>Threshold:</label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input disabled="true" name="attr_FatigueThreshold" type="number" value="floor(@{Willpower}/10)+floor(@{Toughness}/10)">
-            </div>
-            <div class="sheet-item" style="width:16%">
-                <label>Current: </label>
-            </div>
-            <div class="sheet-item" style="width:8%">
-                <input name="attr_Fatigue" type="number">
-            </div>
-        </div>
-        
-        <br>
-        
-        <h3>Armour & Defence</h3>
-        
-        <div class="sheet-2colrow">
-            <div class="sheet-col">
-                <div class="sheet-armourblock"></div>
-                <div class="sheet-quickborder sheet-armourblock">
-                    <label>Head</label> <input name="attr_HArmour" type="number"> <label>(1-10)</label> <input disabled="true" name="attr_HTotal" type="number" value="@{HArmour}+floor(@{Toughness}/10)">
-                </div><br>
-                <div class="sheet-quickborder sheet-armourblock">
-                    <label>AR</label> <input name="attr_ArArmour" type="number"> <label>(11-20)</label> <input disabled="true" name="attr_ArTotal" type="number" value="@{ArArmour}+floor(@{Toughness}/10)">
-                </div>
-                <div class="sheet-quickborder sheet-armourblock">
-                    <label>Body</label> <input name="attr_BArmour" type="number"> <label>(31-70)</label> <input disabled="true" name="attr_BTotal" type="number" value="@{BArmour}+floor(@{Toughness}/10)">
-                </div>
-                <div class="sheet-quickborder sheet-armourblock">
-                    <label>AL</label> <input name="attr_AlArmour" type="number"> <label>(21-30)</label> <input disabled="true" name="attr_AlTotal" type="number" value="@{AlArmour}+floor(@{Toughness}/10)">
-                </div>
-                <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
-                    <label>LR</label> <input name="attr_LrArmour" type="number"> <label>(71-85)</label> <input disabled="true" name="attr_LrTotal" type="number" value="@{LrArmour}+floor(@{Toughness}/10)">
-                </div>
-                <div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;">
-                    <label>LL</label> <input name="attr_LlArmour" type="number"> <label>(86-00)</label> <input disabled="true" name="attr_LlTotal" type="number" value="@{LlArmour}+floor(@{Toughness}/10)">
-                </div>
-            </div>
-        
-            <div class="sheet-col sheet-fate">
-                <h3>Wounds</h3>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:65%">
-                        <label>Total: </label>
-                    </div>
-                    <div class="sheet-item" style="width:20%">
-                        <input name="attr_Wounds_max" type="number">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:65%">
-                        <label>Current: </label>
-                    </div>
-                    <div class="sheet-item" style="width:20%">
-                        <input name="attr_Wounds" type="number">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:65%">
-                        <label>Critical Damage: </label>
-                    </div>
-                    <div class="sheet-item" style="width:20%">
-                        <input name="attr_Critical" type="number">
-                    </div>
-                </div>
-                <h3>Conditions</h3>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_1stCondition" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_1stCondition" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_2ndCondition" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_3rdCondition" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_4thCondition" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_5thCondition" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_6thCondition" type="text">
-                    </div>
-                </div>
-                <div class="sheet-row">
-                    <div class="sheet-item" style="width:100%">
-                        <input name="attr_7thCondition" type="text">
-                    </div>
-                </div>
-            </div>   
-        </div>
-   
-    </div>
-    
-
-    <div class="sheet-col">
-        <h3>Talents & Traits</h3>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:90%">
-                <input name="attr_Talent" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_TalentPage" type="text">
-            </div>
-        </div>
-        <fieldset class="repeating_Talents">
-            <div class="sheet-item" style="width:90%">
-                <input name="attr_Talents" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_TalentsPage" type="text">
-            </div>
-        </fieldset>
-        
-        <h3>Special Abilities</h3>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:100%">
-                <input name="attr_Ability" type="text">
-            </div>
-        </div>
-        <fieldset class="repeating_Abilities">
-            <div class="sheet-item" style="width:100%">
-                <input name="attr_Abilities" type="text">
-            </div>
-        </fieldset> 
-        
-        <h3>Ranged Weapons</h3>
-        <fieldset class="repeating_rangedweapons">
-        <div class="sheet-quickborder">
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:15%">
-                <label>Name:</label>
-            </div>
-            <div class="sheet-item" style="width:55%">
-                <input name="attr_rangedweaponname" type="text">
-            </div>
-            <div class="sheet-item" style="width:12%">
-                <label>Class:</label>
-            </div>
-            <div class="sheet-item" style="width:15%">
-                <input name="attr_rangedweaponclass" type="text">
-            </div>
-        </div>
-
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:12%">
-                <label>Range:</label>
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_rangedweaponrange" type="text">
-            </div>
-            <div class="sheet-item" style="width:15%">
-                <label>Damage:</label>
-            </div>
-            <div class="sheet-item" style="width:15%">
-                <input name="attr_rangedweapondamage" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <label>Type:</label>
-            </div>
-            <div class="sheet-item" style="width:18%">
-                <input name="attr_rangedweapontype" type="text">
-            </div>
-            <div class="sheet-item" style="width:9%">
-                <label>Pen:</label>
-            </div>
-            <div class="sheet-item" style="width:9%">
-                <input name="attr_rangedweaponpen" type="text" value="0">
-            </div>
-        </div>
-
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:9%">
-                <label>RoF:</label>
-            </div>
-            <div class="sheet-item" style="width:6%">
-                <input name="attr_rangedweaponsingle" type="text" value="0">
-            </div>
-            <div class="sheet-item" style="width:2%">
-                <label>/</label>
-            </div>
-            <div class="sheet-item" style="width:6%">
-                <input name="attr_rangedweaponsemi" type="text" value="0">
-            </div>
-            <div class="sheet-item" style="width:2%">
-                <label>/</label>
-            </div>
-            <div class="sheet-item" style="width:6%">
-                <input name="attr_rangedweaponfull" type="text" value="0">
-            </div>
-            <div class="sheet-item" style="width:9%">
-                <label>Clip:</label>
-            </div>
-            <div class="sheet-item" style="width:6%">
-                <input name="attr_rangedweaponclip" type="text" value="0">
-            </div>
-            <div class="sheet-item" style="width:2%">
-                <label>/</label>
-            </div>
-            <div class="sheet-item" style="width:6%">
-                <input name="attr_rangedweaponclip_max" type="text" value="0">
-            </div>
-            
-            <div class="sheet-item" style="width:15%">
-                <label>Reload:</label>
-            </div>
-            <div class="sheet-item" style="width:16%">
-                <input name="attr_rangedweaponreload" type="text">
-            </div>
-            <div class="sheet-item" style="width:16%">
-                <button name="roll_rangeddamage" type="roll" value="/me does [[@{rangedweapondamage}]] @{rangedweapontype} damage! (Pen: @{rangedweaponpen})">
-
-                    <label>Damage</label>
-                </button>
-            </div>
-        </div>
-
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:25%">
-                <label>Special:</label>
-            </div>
-            <div class="sheet-item" style="width:65%">
-                <input name="attr_rangedweaponspecial" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <button name="roll_rangedhit" type="roll" value="/me uses @{rangedweaponname} Roll: [[ (([[@{BallisticSkill}]] + ?{Modifier|0}) -1d100)/10]] degree(s) of success!">
-                    <label>Hit</label>
-                </button>
-            </div>
-        </div>
-        </div>
-        </fieldset>
-        
-        <h3>Gear</h3>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:80%">
-                <input name="attr_Gear" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_GearWt" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_GearPage" type="number">
-            </div>
-        </div>
-        <fieldset class="repeating_Gears">
-            <div class="sheet-item" style="width:80%">
-                <input name="attr_Gears" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_GeasrWt" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_GearsPage" type="text">
-            </div>
-        </fieldset>
-        
-        <div class="sheet-row">
+<div class="sheet-col sheet-skills">
+<table>
+<tbody>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Acrobatics" type="roll" value="/em rolls Acrobatics with [[ ([[@{AcrobaticsCharacteristic} + -20 + @{Acrobatics1} + @{Acrobatics2} + @{Acrobatics3} + @{Acrobatics4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Acrobatics</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_AcrobaticsCharacteristic">
+<option value="@{Agility}">(Ag)</option>
+<option value="@{Strength}">(S)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Acrobatics1" type="checkbox" value="20" /></td>
+<td><input name="attr_Acrobatics2" type="checkbox" value="10" /></td>
+<td><input name="attr_Acrobatics3" type="checkbox" value="10" /></td>
+<td><input name="attr_Acrobatics4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Athletics" type="roll" value="/em rolls Athletics with [[ ([[@{AthleticsCharacteristic} + -20 + @{Athletics1} + @{Athletics2} + @{Athletics3} + @{Athletics4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Athletics</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_AthleticsCharacteristic">
+<option value="@{Strength}">(S)</option>
+<option value="@{Toughness}">(T)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Athletics1" type="checkbox" value="20" /></td>
+<td><input name="attr_Athletics2" type="checkbox" value="10" /></td>
+<td><input name="attr_Athletics3" type="checkbox" value="10" /></td>
+<td><input name="attr_Athletics4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Awareness" type="roll" value="/em rolls Awareness with [[ ([[@{AwarenessCharacteristic} + -20 + @{Awareness1} + @{Awareness2} + @{Awareness3} + @{Awareness4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Awareness</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_AwarenessCharacteristic">
+<option value="@{Perception}">(Per)</option>
+<option value="@{Fellowship}">(Fel)</option>
+<option value="@{Intelligence}">(Int)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Awareness1" type="checkbox" value="20" /></td>
+<td><input name="attr_Awareness2" type="checkbox" value="10" /></td>
+<td><input name="attr_Awareness3" type="checkbox" value="10" /></td>
+<td><input name="attr_Awareness4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Charm" type="roll" value="/em rolls Charm with [[ ([[@{CharmCharacteristic} + -20 + @{Charm1} + @{Charm2} + @{Charm3} + @{Charm4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Charm</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_CharmCharacteristic">
+<option value="@{Fellowship}">(Fel)</option>
+<option value="@{Influence}">(Ifl)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Charm1" type="checkbox" value="20" /></td>
+<td><input name="attr_Charm2" type="checkbox" value="10" /></td>
+<td><input name="attr_Charm3" type="checkbox" value="10" /></td>
+<td><input name="attr_Charm4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Command" type="roll" value="/em rolls Command with [[ ([[@{CommandCharacteristic} + -20 + @{Command1} + @{Command2} + @{Command3} + @{Command4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Command</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_CommandCharacteristic">
+<option value="@{Fellowship}">(Fel)</option>
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Strength}">(S)</option>
+<option value="@{Willpower}">(WP)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Command1" type="checkbox" value="20" /></td>
+<td><input name="attr_Command2" type="checkbox" value="10" /></td>
+<td><input name="attr_Command3" type="checkbox" value="10" /></td>
+<td><input name="attr_Command4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Commerce" type="roll" value="/em rolls Commerce with [[ ([[@{CommerceCharacteristic} + -20 + @{Commerce1} + @{Commerce2} + @{Commerce3} + @{Commerce4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Commerce</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_CommerceCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Fellowship}">(Fel)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Commerce1" type="checkbox" value="20" /></td>
+<td><input name="attr_Commerce2" type="checkbox" value="10" /></td>
+<td><input name="attr_Commerce3" type="checkbox" value="10" /></td>
+<td><input name="attr_Commerce4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Deceive" type="roll" value="/em rolls Deceive with [[ ([[@{DeceiveCharacteristic} + -20 + @{Deceive1} + @{Deceive2} + @{Deceive3} + @{Deceive4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Deceive</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_DeceiveCharacteristic">
+<option value="@{Fellowship}">(Fel)</option>
+<option value="@{Intelligence}">(Int)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Deceive1" type="checkbox" value="20" /></td>
+<td><input name="attr_Deceive2" type="checkbox" value="10" /></td>
+<td><input name="attr_Deceive3" type="checkbox" value="10" /></td>
+<td><input name="attr_Deceive4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Dodge" type="roll" value="/em rolls Dodge with [[ ([[@{DodgeCharacteristic} + -20 + @{Dodge1} + @{Dodge2} + @{Dodge3} + @{Dodge4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Dodge</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_DodgeCharacteristic">
+<option value="@{Agility}">(Ag)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Dodge1" type="checkbox" value="20" /></td>
+<td><input name="attr_Dodge2" type="checkbox" value="10" /></td>
+<td><input name="attr_Dodge3" type="checkbox" value="10" /></td>
+<td><input name="attr_Dodge4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Inquiry" type="roll" value="/em rolls Inquiry with [[ ([[@{InquiryCharacteristic} + -20 + @{Inquiry1} + @{Inquiry2} + @{Inquiry3} + @{Inquiry4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Inquiry</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_InquiryCharacteristic">
+<option value="@{Fellowship}">(Fel)</option>
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Perception}">(Per)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Inquiry1" type="checkbox" value="20" /></td>
+<td><input name="attr_Inquiry2" type="checkbox" value="10" /></td>
+<td><input name="attr_Inquiry3" type="checkbox" value="10" /></td>
+<td><input name="attr_Inquiry4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Interrogation" type="roll" value="/em rolls Interrogation with [[ ([[@{InterrogationCharacteristic} + -20 + @{Interrogation1} + @{Interrogation2} + @{Interrogation3} + @{Interrogation4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Interrogation</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_InterrogationCharacteristic">
+<option value="@{Willpower}">(WP)</option>
+<option value="@{Fellowship}">(Fel)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Interrogation1" type="checkbox" value="20" /></td>
+<td><input name="attr_Interrogation2" type="checkbox" value="10" /></td>
+<td><input name="attr_Interrogation3" type="checkbox" value="10" /></td>
+<td><input name="attr_Interrogation4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Intimidate" type="roll" value="/em rolls Intimidate with [[ ([[@{IntimidateCharacteristic} + -20 + @{Intimidate1} + @{Intimidate2} + @{Intimidate3} + @{Intimidate4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Intimidate</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_IntimidateCharacteristic">
+<option value="@{Strength}">(S)</option>
+<option value="@{Willpower}">(WP)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Intimidate1" type="checkbox" value="20" /></td>
+<td><input name="attr_Intimidate2" type="checkbox" value="10" /></td>
+<td><input name="attr_Intimidate3" type="checkbox" value="10" /></td>
+<td><input name="attr_Intimidate4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Logic" type="roll" value="/em rolls Logic with [[ ([[@{LogicCharacteristic} + -20 + @{Logic1} + @{Logic2} + @{Logic3} + @{Logic4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Logic</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_LogicCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Agility}">(Ag)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Logic1" type="checkbox" value="20" /></td>
+<td><input name="attr_Logic2" type="checkbox" value="10" /></td>
+<td><input name="attr_Logic3" type="checkbox" value="10" /></td>
+<td><input name="attr_Logic4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Medicae" type="roll" value="/em rolls Medicae with [[ ([[@{MedicaeCharacteristic} + -20 + @{Medicae1} + @{Medicae2} + @{Medicae3} + @{Medicae4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Medicae</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_MedicaeCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Agility}">(Ag)</option>
+<option value="@{Perception}">(Per)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Medicae1" type="checkbox" value="20" /></td>
+<td><input name="attr_Medicae2" type="checkbox" value="10" /></td>
+<td><input name="attr_Medicae3" type="checkbox" value="10" /></td>
+<td><input name="attr_Medicae4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><label>Navigate</label></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_NavigateCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Perception}">(Per)</option>
+</select></div>
+</div>
+</td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><button name="roll_Surface" type="roll" value="/em rolls Navigate (Surface) with [[ ([[@{NavigateCharacteristic} + -20 + @{Surface1} + @{Surface2} + @{Surface3} + @{Surface4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Surface</label> </button></div>
+</div>
+</td>
+<td><input name="attr_Surface1" type="checkbox" value="20" /></td>
+<td><input name="attr_Surface2" type="checkbox" value="10" /></td>
+<td><input name="attr_Surface3" type="checkbox" value="10" /></td>
+<td><input name="attr_Surface4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><button name="roll_Stellar" type="roll" value="/em rolls Navigate (Stellar) with [[ ([[@{NavigateCharacteristic} + -20 + @{Stellar1} + @{Stellar2} + @{Stellar3} + @{Stellar4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Stellar</label> </button></div>
+</div>
+</td>
+<td><input name="attr_Stellar1" type="checkbox" value="20" /></td>
+<td><input name="attr_Stellar2" type="checkbox" value="10" /></td>
+<td><input name="attr_Stellar3" type="checkbox" value="10" /></td>
+<td><input name="attr_Stellar4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><button name="roll_Warp" type="roll" value="/em rolls Navigate (Warp) with [[ ([[@{NavigateCharacteristic} + -20 + @{Warp1} + @{Warp2} + @{Warp3} + @{Warp4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Warp</label> </button></div>
+</div>
+</td>
+<td><input name="attr_Warp1" type="checkbox" value="20" /></td>
+<td><input name="attr_Warp2" type="checkbox" value="10" /></td>
+<td><input name="attr_Warp3" type="checkbox" value="10" /></td>
+<td><input name="attr_Warp4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><label>Operate</label></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_OperateCharacteristic">
+<option value="@{Agility}">(Ag)</option>
+<option value="@{Intelligence}">(Int)</option>
+</select></div>
+</div>
+</td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><button name="roll_Aeronautica" type="roll" value="/em rolls Operate (Aeronautica) with [[ ([[@{OperateCharacteristic} + -20 + @{Aeronautica1} + @{Aeronautica2} + @{Aeronautica3} + @{Aeronautica4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Aeronautica</label> </button></div>
+</div>
+</td>
+<td><input name="attr_Aeronautica1" type="checkbox" value="20" /></td>
+<td><input name="attr_Aeronautica2" type="checkbox" value="10" /></td>
+<td><input name="attr_Aeronautica3" type="checkbox" value="10" /></td>
+<td><input name="attr_Aeronautica4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><button name="roll_OSurface" type="roll" value="/em rolls Operate (Surface) with [[ ([[@{OperateCharacteristic} + -20 + @{OSurface1} + @{OSurface2} + @{OSurface3} + @{OSurface4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Surface</label> </button></div>
+</div>
+</td>
+<td><input name="attr_OSurface1" type="checkbox" value="20" /></td>
+<td><input name="attr_OSurface2" type="checkbox" value="10" /></td>
+<td><input name="attr_OSurface3" type="checkbox" value="10" /></td>
+<td><input name="attr_OSurface4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><button name="roll_Voidship" type="roll" value="/em rolls Operate (Voidship) with [[ ([[@{OperateCharacteristic} + -20 + @{Voidship1} + @{Voidship2} + @{Voidship3} + @{Voidship4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Voidship</label> </button></div>
+</div>
+</td>
+<td><input name="attr_Voidship1" type="checkbox" value="20" /></td>
+<td><input name="attr_Voidship2" type="checkbox" value="10" /></td>
+<td><input name="attr_Voidship3" type="checkbox" value="10" /></td>
+<td><input name="attr_Voidship4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Parry" type="roll" value="/em rolls Parry with [[ ([[@{ParryCharacteristic} + -20 + @{Parry1} + @{Parry2} + @{Parry3} + @{Parry4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Parry</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_ParryCharacteristic">
+<option value="@{WeaponSkill}">(WS)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Parry1" type="checkbox" value="20" /></td>
+<td><input name="attr_Parry2" type="checkbox" value="10" /></td>
+<td><input name="attr_Parry3" type="checkbox" value="10" /></td>
+<td><input name="attr_Parry4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Psyniscience" type="roll" value="/em rolls Psyniscience with [[ ([[@{PsyniscienceCharacteristic} + -20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Psyniscience</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_PsyniscienceCharacteristic">
+<option value="@{Perception}">(Per)</option>
+<option value="@{Willpower}">(WP)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Psyniscience1" type="checkbox" value="20" /></td>
+<td><input name="attr_Psyniscience2" type="checkbox" value="10" /></td>
+<td><input name="attr_Psyniscience3" type="checkbox" value="10" /></td>
+<td><input name="attr_Psyniscience4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Scrutiny" type="roll" value="/em rolls Scrutiny with [[ ([[@{ScrutinyCharacteristic} + -20 + @{Scrutiny1} + @{Scrutiny2} + @{Scrutiny3} + @{Scrutiny4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Scrutiny</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_ScrutinyCharacteristic">
+<option value="@{Perception}">(Per)</option>
+<option value="@{Fellowship}">(Fel)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Scrutiny1" type="checkbox" value="20" /></td>
+<td><input name="attr_Scrutiny2" type="checkbox" value="10" /></td>
+<td><input name="attr_Scrutiny3" type="checkbox" value="10" /></td>
+<td><input name="attr_Scrutiny4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Security" type="roll" value="/em rolls Security with [[ ([[@{SecurityCharacteristic} + -20 + @{Security1} + @{Security2} + @{Security3} + @{Security4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Security</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_SecurityCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Agility}">(Ag)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Security1" type="checkbox" value="20" /></td>
+<td><input name="attr_Security2" type="checkbox" value="10" /></td>
+<td><input name="attr_Security3" type="checkbox" value="10" /></td>
+<td><input name="attr_Security4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_SleightOfHand" type="roll" value="/em rolls SleightOfHand with [[ ([[@{SleightOfHandCharacteristic} + -20 + @{SleightOfHand1} + @{SleightOfHand2} + @{SleightOfHand3} + @{SleightOfHand4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>SleightOfHand</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_SleightOfHandCharacteristic">
+<option value="@{Agility}">(Ag)</option>
+<option value="@{Intelligence}">(Int)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_SleightOfHand1" type="checkbox" value="20" /></td>
+<td><input name="attr_SleightOfHand2" type="checkbox" value="10" /></td>
+<td><input name="attr_SleightOfHand3" type="checkbox" value="10" /></td>
+<td><input name="attr_SleightOfHand4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Stealth" type="roll" value="/em rolls Stealth with [[ ([[@{StealthCharacteristic} - 10*@{Size} -20 + @{Stealth1} + @{Stealth2} + @{Stealth3} + @{Stealth4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Stealth</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_StealthCharacteristic">
+<option value="@{Agility}">(Ag)</option>
+<option value="@{Perception}">(Per)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Stealth1" type="checkbox" value="20" /></td>
+<td><input name="attr_Stealth2" type="checkbox" value="10" /></td>
+<td><input name="attr_Stealth3" type="checkbox" value="10" /></td>
+<td><input name="attr_Stealth4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Survival" type="roll" value="/em rolls Survival with [[ ([[@{SurvivalCharacteristic} + -20 + @{Survival1} + @{Survival2} + @{Survival3} + @{Survival4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Survival</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_SurvivalCharacteristic">
+<option value="@{Perception}">(Per)</option>
+<option value="@{Agility}">(Ag)</option>
+<option value="@{Intelligence}">(Int)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_Survival1" type="checkbox" value="20" /></td>
+<td><input name="attr_Survival2" type="checkbox" value="10" /></td>
+<td><input name="attr_Survival3" type="checkbox" value="10" /></td>
+<td><input name="attr_Survival4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_TechUse" type="roll" value="/em rolls Tech-Use with [[ ([[@{TechUseCharacteristic} + -20 + @{TechUse1} + @{TechUse2} + @{TechUse3} + @{TechUse4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Tech-Use</label> </button></div>
+<div class="sheet-item" style="width: 45%;"><select class="charaselect" name="attr_TechUseCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Agility}">(Ag)</option>
+</select></div>
+</div>
+</td>
+<td><input name="attr_TechUse1" type="checkbox" value="20" /></td>
+<td><input name="attr_TechUse2" type="checkbox" value="10" /></td>
+<td><input name="attr_TechUse3" type="checkbox" value="10" /></td>
+<td><input name="attr_TechUse4" type="checkbox" value="10" /></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sheet-col sheet-skills">
+<table>
+<tbody>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 60%;"><label>Linguistics</label></div>
+<div class="sheet-item" style="width: 40%;"><select class="charaselect" name="attr_LinguisticsCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Fellowship}">(Fel)</option>
+</select></div>
+</div>
+</td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_1stLanguage" type="roll" value="/em rolls @{1stLanguage} with [[ ([[@{LinguisticsCharacteristic} + -20 + @{1stLanguage1} + @{1stLanguage2} + @{1stLanguage3} + @{1stLanguage4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_1stLanguage" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_1stLanguage1" type="checkbox" value="20" /></td>
+<td><input name="attr_1stLanguage2" type="checkbox" value="10" /></td>
+<td><input name="attr_1stLanguage3" type="checkbox" value="10" /></td>
+<td><input name="attr_1stLanguage4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_2ndLanguage" type="roll" value="/em rolls @{2ndLanguage} with [[ ([[@{LinguisticsCharacteristic} + -20 + @{2ndLanguage1} + @{2ndLanguage2} + @{2ndLanguage3} + @{2ndLanguage4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_2ndLanguage" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_2ndLanguage1" type="checkbox" value="20" /></td>
+<td><input name="attr_2ndLanguage2" type="checkbox" value="10" /></td>
+<td><input name="attr_2ndLanguage3" type="checkbox" value="10" /></td>
+<td><input name="attr_2ndLanguage4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_3rdLanguage" type="roll" value="/em rolls @{3rdLanguage} with [[ ([[@{LinguisticsCharacteristic} + -20 + @{3rdLanguage1} + @{3rdLanguage2} + @{3rdLanguage3} + @{3rdLanguage4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_3rdLanguage" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_3rdLanguage1" type="checkbox" value="20" /></td>
+<td><input name="attr_3rdLanguage2" type="checkbox" value="10" /></td>
+<td><input name="attr_3rdLanguage3" type="checkbox" value="10" /></td>
+<td><input name="attr_3rdLanguage4" type="checkbox" value="10" /></td>
+</tr>
+<!-- ====================== Trade ====================== -->
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 60%;"><label>Trade</label></div>
+<div class="sheet-item" style="width: 40%;"><select class="charaselect" name="attr_TradeCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Agility}">(Ag)</option>
+<option value="@{Fellowship}">(Fel)</option>
+</select></div>
+</div>
+</td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_1stTrade" type="roll" value="/em rolls @{1stTrade} with [[ ([[@{TradeCharacteristic} + -20 + @{1stTrade1} + @{1stTrade2} + @{1stTrade3} + @{1stTrade4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_1stTrade" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_1stTrade1" type="checkbox" value="20" /></td>
+<td><input name="attr_1stTrade2" type="checkbox" value="10" /></td>
+<td><input name="attr_1stTrade3" type="checkbox" value="10" /></td>
+<td><input name="attr_1stTrade4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_2ndTrade" type="roll" value="/em rolls @{2ndTrade} with [[ ([[@{TradeCharacteristic} + -20 + @{2ndTrade1} + @{2ndTrade2} + @{2ndTrade3} + @{2ndTrade4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_2ndTrade" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_2ndTrade1" type="checkbox" value="20" /></td>
+<td><input name="attr_2ndTrade2" type="checkbox" value="10" /></td>
+<td><input name="attr_2ndTrade3" type="checkbox" value="10" /></td>
+<td><input name="attr_2ndTrade4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_3rdTrade" type="roll" value="/em rolls @{3rdTrade} with [[ ([[@{TradeCharacteristic} + -20 + @{3rdTrade1} + @{3rdTrade2} + @{3rdTrade3} + @{3rdTrade4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_3rdTrade" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_3rdTrade1" type="checkbox" value="20" /></td>
+<td><input name="attr_3rdTrade2" type="checkbox" value="10" /></td>
+<td><input name="attr_3rdTrade3" type="checkbox" value="10" /></td>
+<td><input name="attr_3rdTrade4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_4thTrade" type="roll" value="/em rolls @{4thTrade} with [[ ([[@{TradeCharacteristic} + -20 + @{4thTrade1} + @{4thTrade2} + @{4thTrade3} + @{4thTrade4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_4thTrade" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_4thTrade1" type="checkbox" value="20" /></td>
+<td><input name="attr_4thTrade2" type="checkbox" value="10" /></td>
+<td><input name="attr_4thTrade3" type="checkbox" value="10" /></td>
+<td><input name="attr_4thTrade4" type="checkbox" value="10" /></td>
+</tr>
+<!-- ====================== Lore ====================== -->
+<tr>
+<td><label>Lore</label></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 60%;"><label>Common</label></div>
+<div class="sheet-item" style="width: 40%;"><select class="charaselect" name="attr_CommonLoreCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Fellowship}">(Fel)</option>
+</select></div>
+</div>
+</td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_1stCommon" type="roll" value="/em rolls @{1stCommon} with [[ ([[@{CommonLoreCharacteristic} + -20 + @{1stCommon1} + @{1stCommon2} + @{1stCommon3} + @{1stCommon4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_1stCommon" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_1stCommon1" type="checkbox" value="20" /></td>
+<td><input name="attr_1stCommon2" type="checkbox" value="10" /></td>
+<td><input name="attr_1stCommon3" type="checkbox" value="10" /></td>
+<td><input name="attr_1stCommon4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_2ndCommon" type="roll" value="/em rolls @{2ndCommon} with [[ ([[@{CommonLoreCharacteristic} + -20 + @{2ndCommon1} + @{2ndCommon2} + @{2ndCommon3} + @{2ndCommon4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_2ndCommon" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_2ndCommon1" type="checkbox" value="20" /></td>
+<td><input name="attr_2ndCommon2" type="checkbox" value="10" /></td>
+<td><input name="attr_2ndCommon3" type="checkbox" value="10" /></td>
+<td><input name="attr_2ndCommon4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_3rdCommon" type="roll" value="/em rolls @{3rdCommon} with [[ ([[@{CommonLoreCharacteristic} + -20 + @{3rdCommon1} + @{3rdCommon2} + @{3rdCommon3} + @{3rdCommon4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_3rdCommon" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_3rdCommon1" type="checkbox" value="20" /></td>
+<td><input name="attr_3rdCommon2" type="checkbox" value="10" /></td>
+<td><input name="attr_3rdCommon3" type="checkbox" value="10" /></td>
+<td><input name="attr_3rdCommon4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_4thCommon" type="roll" value="/em rolls @{4thCommon} with [[ ([[@{CommonLoreCharacteristic} + -20 + @{4thCommon1} + @{4thCommon2} + @{4thCommon3} + @{4thCommon4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_4thCommon" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_4thCommon1" type="checkbox" value="20" /></td>
+<td><input name="attr_4thCommon2" type="checkbox" value="10" /></td>
+<td><input name="attr_4thCommon3" type="checkbox" value="10" /></td>
+<td><input name="attr_4thCommon4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 60%;"><label>Scholastic</label></div>
+<div class="sheet-item" style="width: 40%;"><select class="charaselect" name="attr_ScholasticLoreCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Fellowship}">(Fel)</option>
+</select></div>
+</div>
+</td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_1stScholastic" type="roll" value="/em rolls @{1stScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{1stScholastic1} + @{1stScholastic2} + @{1stScholastic3} + @{1stScholastic4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_1stScholastic" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_1stScholastic1" type="checkbox" value="20" /></td>
+<td><input name="attr_1stScholastic2" type="checkbox" value="10" /></td>
+<td><input name="attr_1stScholastic3" type="checkbox" value="10" /></td>
+<td><input name="attr_1stScholastic4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_2ndScholastic" type="roll" value="/em rolls @{2ndScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{2ndScholastic1} + @{2ndScholastic2} + @{2ndScholastic3} + @{2ndScholastic4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_2ndScholastic" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_2ndScholastic1" type="checkbox" value="20" /></td>
+<td><input name="attr_2ndScholastic2" type="checkbox" value="10" /></td>
+<td><input name="attr_2ndScholastic3" type="checkbox" value="10" /></td>
+<td><input name="attr_2ndScholastic4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_3rdScholastic" type="roll" value="/em rolls @{3rdScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{3rdScholastic1} + @{3rdScholastic2} + @{3rdScholastic3} + @{3rdScholastic4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_3rdScholastic" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_3rdScholastic1" type="checkbox" value="20" /></td>
+<td><input name="attr_3rdScholastic2" type="checkbox" value="10" /></td>
+<td><input name="attr_3rdScholastic3" type="checkbox" value="10" /></td>
+<td><input name="attr_3rdScholastic4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_4thScholastic" type="roll" value="/em rolls @{4thScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{4thScholastic1} + @{4thScholastic2} + @{4thScholastic3} + @{4thScholastic4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_4thScholastic" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_4thScholastic1" type="checkbox" value="20" /></td>
+<td><input name="attr_4thScholastic2" type="checkbox" value="10" /></td>
+<td><input name="attr_4thScholastic3" type="checkbox" value="10" /></td>
+<td><input name="attr_4thScholastic4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_5thScholastic" type="roll" value="/em rolls @{5thScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{5thScholastic1} + @{5thScholastic2} + @{5thScholastic3} + @{5thScholastic4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_5thScholastic" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_5thScholastic1" type="checkbox" value="20" /></td>
+<td><input name="attr_5thScholastic2" type="checkbox" value="10" /></td>
+<td><input name="attr_5thScholastic3" type="checkbox" value="10" /></td>
+<td><input name="attr_5thScholastic4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_6thScholastic" type="roll" value="/em rolls @{6thScholastic} with [[ ([[@{ScholasticLoreCharacteristic} + -20 + @{6thScholastic1} + @{6thScholastic2} + @{6thScholastic3} + @{6thScholastic4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_6thScholastic" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_6thScholastic1" type="checkbox" value="20" /></td>
+<td><input name="attr_6thScholastic2" type="checkbox" value="10" /></td>
+<td><input name="attr_6thScholastic3" type="checkbox" value="10" /></td>
+<td><input name="attr_6thScholastic4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 60%;"><label>Forbidden</label></div>
+<div class="sheet-item" style="width: 40%;"><select class="charaselect" name="attr_ForbiddenLoreCharacteristic">
+<option value="@{Intelligence}">(Int)</option>
+<option value="@{Fellowship}">(Fel)</option>
+</select></div>
+</div>
+</td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_1stForbidden" type="roll" value="/em rolls @{1stForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{1stForbidden1} + @{1stForbidden2} + @{1stForbidden3} + @{1stForbidden4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_1stForbidden" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_1stForbidden1" type="checkbox" value="20" /></td>
+<td><input name="attr_1stForbidden2" type="checkbox" value="10" /></td>
+<td><input name="attr_1stForbidden3" type="checkbox" value="10" /></td>
+<td><input name="attr_1stForbidden4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_2ndForbidden" type="roll" value="/em rolls @{2ndForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{2ndForbidden1} + @{2ndForbidden2} + @{2ndForbidden3} + @{2ndForbidden4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_2ndForbidden" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_2ndForbidden1" type="checkbox" value="20" /></td>
+<td><input name="attr_2ndForbidden2" type="checkbox" value="10" /></td>
+<td><input name="attr_2ndForbidden3" type="checkbox" value="10" /></td>
+<td><input name="attr_2ndForbidden4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_3rdForbidden" type="roll" value="/em rolls @{3rdForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{3rdForbidden1} + @{3rdForbidden2} + @{3rdForbidden3} + @{3rdForbidden4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_3rdForbidden" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_3rdForbidden1" type="checkbox" value="20" /></td>
+<td><input name="attr_3rdForbidden2" type="checkbox" value="10" /></td>
+<td><input name="attr_3rdForbidden3" type="checkbox" value="10" /></td>
+<td><input name="attr_3rdForbidden4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_4thForbidden" type="roll" value="/em rolls @{4thForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{4thForbidden1} + @{4thForbidden2} + @{4thForbidden3} + @{4thForbidden4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_4thForbidden" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_4thForbidden1" type="checkbox" value="20" /></td>
+<td><input name="attr_4thForbidden2" type="checkbox" value="10" /></td>
+<td><input name="attr_4thForbidden3" type="checkbox" value="10" /></td>
+<td><input name="attr_4thForbidden4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_5thForbidden" type="roll" value="/em rolls @{5thForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{5thForbidden1} + @{5thForbidden2} + @{5thForbidden3} + @{5thForbidden4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_5thForbidden" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_5thForbidden1" type="checkbox" value="20" /></td>
+<td><input name="attr_5thForbidden2" type="checkbox" value="10" /></td>
+<td><input name="attr_5thForbidden3" type="checkbox" value="10" /></td>
+<td><input name="attr_5thForbidden4" type="checkbox" value="10" /></td>
+</tr>
+<tr>
+<td>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><button name="roll_6thForbidden" type="roll" value="/em rolls @{6thForbidden} with [[ ([[@{ForbiddenLoreCharacteristic} + -20 + @{6thForbidden1} + @{6thForbidden2} + @{6thForbidden3} + @{6thForbidden4} + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> </button></div>
+<div class="sheet-item" style="width: 80%;"><input name="attr_6thForbidden" type="text" /></div>
+</div>
+</td>
+<td><input name="attr_6thForbidden1" type="checkbox" value="20" /></td>
+<td><input name="attr_6thForbidden2" type="checkbox" value="10" /></td>
+<td><input name="attr_6thForbidden3" type="checkbox" value="10" /></td>
+<td><input name="attr_6thForbidden4" type="checkbox" value="10" /></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<!-- Second Part = Aptitudes\Talents&Traits\Melee&Raged Weapons --> <br /> <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+<div class="sheet-2colrow">
+<div class="sheet-col">
+<h3>Aptitudes</h3>
+<div class="sheet-2colrow">
+<div class="sheet-col">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_1stAptitude" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_2ndAptitude" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_3rdAptitude" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_4thAptitude" type="text" /></div>
+</div>
+</div>
+<div class="sheet-col">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_5thAptitude" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_6thAptitude" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_7thAptitude" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_8thAptitude" type="text" /></div>
+</div>
+</div>
+</div>
+<br />
+<h3>Melee Weapons</h3>
+<fieldset class="repeating_meleeweapons">
+<div class="sheet-quickborder">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Name:</label></div>
+<div class="sheet-item" style="width: 55%;"><input name="attr_meleeweaponname" type="text" /></div>
+<div class="sheet-item" style="width: 12%;"><label>Class:</label></div>
+<div class="sheet-item" style="width: 19%;"><input name="attr_meleeweaponclass" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Damage:</label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_meleeweapondamage" type="text" /></div>
+<div class="sheet-item" style="width: 12%;"><label>Type:</label></div>
+<div class="sheet-item" style="width: 18%;"><input name="attr_meleeweapontype" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><label>Pen:</label></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_meleeweaponpen" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 16%;"><button name="roll_meleedamage" type="roll" value="/me does [[@{meleeweapondamage}+@{MutS}+(floor(@{strength}/10))]] @{meleeweapontype} damage! (Pen: @{meleeweaponpen})"> <label>Damage</label> </button></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
+<div class="sheet-item" style="width: 75%;"><input name="attr_meleeweaponspecial" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><button name="roll_meleehit" type="roll" value="/me uses @{meleeweaponname} Roll: [[ (([[@{WeaponSkill}]] + ?{Modifier|0}) -1d100)/10]] additional degree(s) of success!"> <label>Hit</label> </button></div>
+</div>
+</div>
+</fieldset>
+<h3>Movement</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><label>Half Move: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_HalfMove" type="number" value="floor(@{Agility}/10)+@{MutAg}+@{Size}" /></div>
+<div class="sheet-item" style="width: 20%;"><label>Full Move: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_FullMove" type="number" value="2*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
+<div class="sheet-item" style="width: 16%;"><label>Charge: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_ChargeMove" type="number" value="3*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
+<div class="sheet-item" style="width: 10%;"><label>Run: </label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_RunMove" type="number" value="6*(floor(@{Agility}/10)+@{MutAg}+@{Size})" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 28%;"><label>Fatigue</label></div>
+<div class="sheet-item" style="width: 20%;"><label>Threshold:</label></div>
+<div class="sheet-item" style="width: 8%;"><input disabled="disabled" name="attr_FatigueThreshold" type="number" value="@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-item" style="width: 16%;"><label>Current: </label></div>
+<div class="sheet-item" style="width: 8%;"><input name="attr_Fatigue" type="number" /></div>
+</div>
+<br />
+<h3>Armour &amp; Defence</h3>
+<div class="sheet-2colrow">
+<div class="sheet-col">
+<div class="sheet-armourblock">&nbsp;</div>
+<div class="sheet-quickborder sheet-armourblock"><label>Head</label> <input name="attr_HArmour" type="number" /> <label>(1-10)</label> <input disabled="disabled" name="attr_HTotal" type="number" value="@{HArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<br />
+<div class="sheet-quickborder sheet-armourblock"><label>AR</label> <input name="attr_ArArmour" type="number" /> <label>(11-20)</label> <input disabled="disabled" name="attr_ArTotal" type="number" value="@{ArArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock"><label>Body</label> <input name="attr_BArmour" type="number" /> <label>(31-70)</label> <input disabled="disabled" name="attr_BTotal" type="number" value="@{BArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock"><label>AL</label> <input name="attr_AlArmour" type="number" /> <label>(21-30)</label> <input disabled="disabled" name="attr_AlTotal" type="number" value="@{AlArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;"><label>LR</label> <input name="attr_LrArmour" type="number" /> <label>(71-85)</label> <input disabled="disabled" name="attr_LrTotal" type="number" value="@{LrArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+<div class="sheet-quickborder sheet-armourblock" style="margin: 20px auto auto 11%;"><label>LL</label> <input name="attr_LlArmour" type="number" /> <label>(86-00)</label> <input disabled="disabled" name="attr_LlTotal" type="number" value="@{LlArmour}+@{MutT}+floor(@{Toughness}/10)" /></div>
+</div>
+<div class="sheet-col sheet-fate">
+<h3>Wounds</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 65%;"><label>Total: </label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Wounds_max" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 65%;"><label>Current: </label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Wounds" type="number" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 65%;"><label>Critical Damage: </label></div>
+<div class="sheet-item" style="width: 20%;"><input name="attr_Critical" type="number" /></div>
+</div>
+<h3>Conditions</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_1stCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_1stCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_2ndCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_3rdCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_4thCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_5thCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_6thCondition" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_7thCondition" type="text" /></div>
+</div>
+</div>
+</div>
+</div>
+<div class="sheet-col">
+<h3>Talents &amp; Traits</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 90%;"><input name="attr_Talent" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_TalentPage" type="text" /></div>
+</div>
+<fieldset class="repeating_Talents">
+<div class="sheet-item" style="width: 90%;"><input name="attr_Talents" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_TalentsPage" type="text" /></div>
+</fieldset>
+<h3>Special Abilities</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Ability" type="text" /></div>
+</div>
+<fieldset class="repeating_Abilities">
+<div class="sheet-item" style="width: 100%;"><input name="attr_Abilities" type="text" /></div>
+</fieldset>
+<h3>Ranged Weapons</h3>
+<fieldset class="repeating_rangedweapons">
+<div class="sheet-quickborder">
+<div class="sheet-row">
+<div class="sheet-item" style="width: 15%;"><label>Name:</label></div>
+<div class="sheet-item" style="width: 55%;"><input name="attr_rangedweaponname" type="text" /></div>
+<div class="sheet-item" style="width: 12%;"><label>Class:</label></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_rangedweaponclass" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 12%;"><label>Range:</label></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_rangedweaponrange" type="text" /></div>
+<div class="sheet-item" style="width: 15%;"><label>Damage:</label></div>
+<div class="sheet-item" style="width: 15%;"><input name="attr_rangedweapondamage" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><label>Type:</label></div>
+<div class="sheet-item" style="width: 18%;"><input name="attr_rangedweapontype" type="text" /></div>
+<div class="sheet-item" style="width: 9%;"><label>Pen:</label></div>
+<div class="sheet-item" style="width: 9%;"><input name="attr_rangedweaponpen" type="text" value="0" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 9%;"><label>RoF:</label></div>
+<div class="sheet-item" style="width: 6%;"><input name="attr_rangedweaponsingle" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 2%;"><label>/</label></div>
+<div class="sheet-item" style="width: 6%;"><input name="attr_rangedweaponsemi" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 2%;"><label>/</label></div>
+<div class="sheet-item" style="width: 6%;"><input name="attr_rangedweaponfull" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 9%;"><label>Clip:</label></div>
+<div class="sheet-item" style="width: 6%;"><input name="attr_rangedweaponclip" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 2%;"><label>/</label></div>
+<div class="sheet-item" style="width: 6%;"><input name="attr_rangedweaponclip_max" type="text" value="0" /></div>
+<div class="sheet-item" style="width: 15%;"><label>Reload:</label></div>
+<div class="sheet-item" style="width: 16%;"><input name="attr_rangedweaponreload" type="text" /></div>
+<div class="sheet-item" style="width: 16%;"><button name="roll_rangeddamage" type="roll" value="/me does [[@{rangedweapondamage}]] @{rangedweapontype} damage! (Pen: @{rangedweaponpen})"> <label>Damage</label> </button></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 25%;"><label>Special:</label></div>
+<div class="sheet-item" style="width: 65%;"><input name="attr_rangedweaponspecial" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><button name="roll_rangedhit" type="roll" value="/me uses @{rangedweaponname} Roll: [[ (([[@{BallisticSkill}]] + ?{Modifier|0}) -1d100)/10]] additional degree(s) of success!"> <label>Hit</label> </button></div>
+</div>
+</div>
+</fieldset>
+<h3>Gear</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 80%;"><input name="attr_Gear" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_GearWt" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_GearPage" type="number" /></div>
+</div>
+<fieldset class="repeating_Gears">
+<div class="sheet-item" style="width: 80%;"><input name="attr_Gears" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_GeasrWt" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_GearsPage" type="text" /></div>
+</fieldset>
+<div class="sheet-col">
+<div class="sheet-row">
             <div class="sheet-item" style="width:40%">
                 <label>Max Carry WT (SB+TB): </label>
             </div>
@@ -2078,51 +1313,56 @@
                 <input name="attr_Carry" type="text">
             </div>
         </div>
-        
-        <h3>Psychic Powers</h3>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:40%">
-                <label>Psy Rating:</label>
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_PsyRating" type="number">
-            </div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:90%">
-                <input name="attr_PsyPower" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_PsyPowerPage" type="text">
-            </div>
-        </div>
-        <fieldset class="repeating_PsyPowers">
-            <div class="sheet-item" style="width:90%">
-                <input name="attr_PsyPowers" type="text">
-            </div>
-            <div class="sheet-item" style="width:10%">
-                <input name="attr_PsyPowersPage" type="text">
-            </div>
-        </fieldset>
-        <h3>Comrade</h3>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:20%"><label>Name</label></div>
-            <div class="sheet-item" style="width:75%"><input name="attr_Comrade_name" type="text"></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:20%"><label>Status</label></div>
-            <div class="sheet-item" style="width:75%"><input name="attr_Comrade_Status" type="text"></div>
-        </div>
-        <div class="sheet-row">
-            <div class="sheet-item" style="width:30%"><label>Special Abilities</label></div>
-            <div class="sheet-item" style="width:65%"><input name="attr_Comrade_Special_Abilities" type="text"></div>
-        </div>
-        <fieldset class="repeating_Comrade_Special_Abilities">
-            <div class="sheet-item" style="width:95%">
-                <input name="attr_more_Comrade_Special_Abilities" type="text">
-            </div>
-        </fieldset>
-    </div>
 </div>
-
+<h3>Psychic Powers</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 40%;"><label>Psy Rating:</label></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_PsyRating" type="number" /></div>
 </div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 90%;"><input name="attr_PsyPower" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_PsyPowerPage" type="text" /></div>
+</div>
+<fieldset class="repeating_PsyPowers">
+<div class="sheet-item" style="width: 90%;"><input name="attr_PsyPowers" type="text" /></div>
+<div class="sheet-item" style="width: 10%;"><input name="attr_PsyPowersPage" type="text" /></div>
+</fieldset>
+<h3>Focus Power Test</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 55%;"><button name="roll_Fettered" type="roll" value="/em fetters their power with [[ ([[@{Willpower} + ceil(@{PsyRating}/2) *5 + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Fettered</label> </button></div>
+<div class="sheet-item" style="width: 55%;"><button name="roll_Unfettered" type="roll" value="/em focuses their unfettered power with [[ ([[@{Willpower} + 5*@{PsyRating} + ?{Modifier|0}]]-1d100)/10]] ]] additional degree(s) of success!"> <label>Unfettered</label> </button></div>
+<div class="sheet-item" style="width: 55%;"><button name="roll_Push" type="roll" value="/em pushes their power to it's limits with [[ ([[@{Willpower} + 5*(@{PsyRating}+?{Psy Push|0}) + ?{Modifier|0}]]-1d100)/10]] additional degree(s) of success!"> <label>Push</label> </button></div>
+<h3>Comrade</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><label>Name</label></div>
+<div class="sheet-item" style="width: 75%;"><input name="attr_Comrade_name" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 20%;"><label>Status</label></div>
+<div class="sheet-item" style="width: 75%;"><input name="attr_Comrade_Status" type="text" /></div>
+</div>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 30%;"><label>Special Abilities</label></div>
+<div class="sheet-item" style="width: 65%;"><input name="attr_Comrade_Special_Abilities" type="text" /></div>
+</div>
+<fieldset class="repeating_Comrade_Special_Abilities">
+<div class="sheet-item" style="width: 95%;"><input name="attr_more_Comrade_Special_Abilities" type="text" /></div>
+</fieldset>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h3>Size</h3>
+<div class="sheet-row">
+<div class="sheet-item" style="width: 45%;"><select class="sizeselect" name="attr_Size">
+<option value="-3">Miniscule (1)</option>
+<option value="-2">Puny (2)</option>
+<option value="-1">Weedy (3)</option>
+<option value="0">Average (4)</option>
+<option value="1">Hulking (5)</option>
+<option value="2">Enormous (6)</option>
+<option value="3">Massive (7)</option>
+<option value="4">Immense (8)</option>
+<option value="5">Monumental (9)</option>
+<option value="6">Titanic (10)</option>


### PR DESCRIPTION
A further update to the Only War sheet including the following:

Replaced characteristic tickboxes with Unnatural Attributes numeric input 
weapon skill damage picks up on unnatural strength 
move speed picks up on unnatural agility 
total armour soak picks up on unnatural toughness 
fatigue threshhold picks up on unnatural toughness 
fatigue threshhold now only picks up on toughness attribute as Willpower bonus effecting this stat is not RAW in OW and is from DH2e. 
Replace characteristic rolls with dialogue including accurate additional degrees of success 
Included a new dialogue for psychic power tests, allow rolls either fettered, unfettered or at push level.
Pick up on Psy rating for rolls including the +5 bonus to roll per psy level used. 
Character size dropdown option, will directly influence stealth rolls and move speeds. 
Updated to reflect degrees of success accurately (0 additional is a successful roll, 1 additional is an additional degree of success.)